### PR TITLE
chore: fix golangci.yml issues (timeout, format)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,10 +95,11 @@ linters:
     - gomnd
 
 run:
-  deadline: 10m
+  timeout: 10m
 
 output:
-  formats: colored-line-number
+  formats:
+    - format: colored-line-number
   print-issued-lines: true
   print-linter-name: true
 

--- a/config/crd/external/authorino.kuadrant.io_authconfigs.yaml
+++ b/config/crd/external/authorino.kuadrant.io_authconfigs.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: authconfigs.authorino.kuadrant.io
 spec:
   group: authorino.kuadrant.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,6 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:


### PR DESCRIPTION
Found that the `deadline: 10m` was incorrect, the correct way to set the timeout is `timeout: 10m` (per https://golangci-lint.run/usage/configuration/). I think this should address the issue that popped up in running the github actions.

While fixing this, also found that the way we set the format was incorrect, `formats` requires an array, we were passing a string. 

Also included changes from running `make` post bumping down controller-gen versions while bumping down go.mod version to 1.21. 
