### PR TITLE
feat(routing): reconciles routing resources 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,6 +90,7 @@ linters-settings:
   varnamelen: 
     ignore-names:
       - g # g Gomega
+      - vs # VirtualService
 linters:
   enable-all: true
   disable:

--- a/config/crd/external/config.openshift.io_ingresses.yaml
+++ b/config/crd/external/config.openshift.io_ingresses.yaml
@@ -1,0 +1,334 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: ingresses.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Ingress
+    listKind: IngressList
+    plural: ingresses
+    singular: ingress
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Ingress holds cluster-wide information about ingress, including the default ingress domain used for routes. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                appsDomain:
+                  description: appsDomain is an optional domain to use instead of the one specified in the domain field when a Route is created without specifying an explicit host. If appsDomain is nonempty, this value is used to generate default host values for Route. Unlike domain, appsDomain may be modified after installation. This assumes a new ingresscontroller has been setup with a wildcard certificate.
+                  type: string
+                componentRoutes:
+                  description: "componentRoutes is an optional list of routes that are managed by OpenShift components that a cluster-admin is able to configure the hostname and serving certificate for. The namespace and name of each route in this list should match an existing entry in the status.componentRoutes list. \n To determine the set of configurable Routes, look at namespace and name of entries in the .status.componentRoutes list, where participating operators write the status of configurable routes."
+                  type: array
+                  items:
+                    description: ComponentRouteSpec allows for configuration of a route's hostname and serving certificate.
+                    type: object
+                    required:
+                      - hostname
+                      - name
+                      - namespace
+                    properties:
+                      hostname:
+                        description: hostname is the hostname that should be used by the route.
+                        type: string
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      name:
+                        description: "name is the logical name of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 256
+                        minLength: 1
+                      namespace:
+                        description: "namespace is the namespace of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      servingCertKeyPairSecret:
+                        description: servingCertKeyPairSecret is a reference to a secret of type `kubernetes.io/tls` in the openshift-config namespace. The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name. If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced secret
+                            type: string
+                  x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                  x-kubernetes-list-type: map
+                domain:
+                  description: "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\". \n It is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\". \n Once set, changing domain is not currently supported."
+                  type: string
+                loadBalancer:
+                  description: loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure provider of the current cluster and are required for Ingress Controller to work on OpenShift.
+                  type: object
+                  properties:
+                    platform:
+                      description: platform holds configuration specific to the underlying infrastructure provider for the ingress load balancers. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
+                      type: object
+                      properties:
+                        aws:
+                          description: aws contains settings specific to the Amazon Web Services infrastructure provider.
+                          type: object
+                          required:
+                            - type
+                          properties:
+                            type:
+                              description: "type allows user to set a load balancer type. When this field is set the default ingresscontroller will get created using the specified LBType. If this field is not set then the default ingress controller of LBType Classic will be created. Valid values are: \n * \"Classic\": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb \n * \"NLB\": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
+                              type: string
+                              enum:
+                                - NLB
+                                - Classic
+                        type:
+                          description: type is the underlying infrastructure provider for the cluster. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                          type: string
+                          enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                requiredHSTSPolicies:
+                  description: "requiredHSTSPolicies specifies HSTS policies that are required to be set on newly created  or updated routes matching the domainPattern/s and namespaceSelector/s that are specified in the policy. Each requiredHSTSPolicy must have at least a domainPattern and a maxAge to validate a route HSTS Policy route annotation, and affect route admission. \n A candidate route is checked for HSTS Policies if it has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\" E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains \n - For each candidate route, if it matches a requiredHSTSPolicy domainPattern and optional namespaceSelector, then the maxAge, preloadPolicy, and includeSubdomainsPolicy must be valid to be admitted.  Otherwise, the route is rejected. - The first match, by domainPattern and optional namespaceSelector, in the ordering of the RequiredHSTSPolicies determines the route's admission status. - If the candidate route doesn't match any requiredHSTSPolicy domainPattern and optional namespaceSelector, then it may use any HSTS Policy annotation. \n The HSTS policy configuration may be changed after routes have already been created. An update to a previously admitted route may then fail if the updated route does not conform to the updated HSTS policy configuration. However, changing the HSTS policy configuration will not cause a route that is already admitted to stop working. \n Note that if there are no RequiredHSTSPolicies, any HSTS Policy annotation on the route is valid."
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - domainPatterns
+                    properties:
+                      domainPatterns:
+                        description: "domainPatterns is a list of domains for which the desired HSTS annotations are required. If domainPatterns is specified and a route is created with a spec.host matching one of the domains, the route must specify the HSTS Policy components described in the matching RequiredHSTSPolicy. \n The use of wildcards is allowed like this: *.foo.com matches everything under foo.com. foo.com only matches foo.com, so to cover foo.com and everything under it, you must specify *both*."
+                        type: array
+                        minItems: 1
+                        items:
+                          type: string
+                      includeSubDomainsPolicy:
+                        description: 'includeSubDomainsPolicy means the HSTS Policy should apply to any subdomains of the host''s domain name.  Thus, for the host bar.foo.com, if includeSubDomainsPolicy was set to RequireIncludeSubDomains: - the host app.bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host foo.com would NOT inherit the HSTS Policy of bar.foo.com - the host def.foo.com would NOT inherit the HSTS Policy of bar.foo.com'
+                        type: string
+                        enum:
+                          - RequireIncludeSubDomains
+                          - RequireNoIncludeSubDomains
+                          - NoOpinion
+                      maxAge:
+                        description: maxAge is the delta time range in seconds during which hosts are regarded as HSTS hosts. If set to 0, it negates the effect, and hosts are removed as HSTS hosts. If set to 0 and includeSubdomains is specified, all subdomains of the host are also removed as HSTS hosts. maxAge is a time-to-live value, and if this policy is not refreshed on a client, the HSTS policy will eventually expire on that client.
+                        type: object
+                        properties:
+                          largestMaxAge:
+                            description: The largest allowed value (in seconds) of the RequiredHSTSPolicy max-age This value can be left unspecified, in which case no upper limit is enforced.
+                            type: integer
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                          smallestMaxAge:
+                            description: The smallest allowed value (in seconds) of the RequiredHSTSPolicy max-age Setting max-age=0 allows the deletion of an existing HSTS header from a host.  This is a necessary tool for administrators to quickly correct mistakes. This value can be left unspecified, in which case no lower limit is enforced.
+                            type: integer
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                      namespaceSelector:
+                        description: namespaceSelector specifies a label selector such that the policy applies only to those routes that are in namespaces with labels that match the selector, and are in one of the DomainPatterns. Defaults to the empty LabelSelector, which matches everything.
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            additionalProperties:
+                              type: string
+                        x-kubernetes-map-type: atomic
+                      preloadPolicy:
+                        description: preloadPolicy directs the client to include hosts in its host preload list so that it never needs to do an initial load to get the HSTS header (note that this is not defined in RFC 6797 and is therefore client implementation-dependent).
+                        type: string
+                        enum:
+                          - RequirePreload
+                          - RequireNoPreload
+                          - NoOpinion
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                componentRoutes:
+                  description: componentRoutes is where participating operators place the current route status for routes whose hostnames and serving certificates can be customized by the cluster-admin.
+                  type: array
+                  items:
+                    description: ComponentRouteStatus contains information allowing configuration of a route's hostname and serving certificate.
+                    type: object
+                    required:
+                      - defaultHostname
+                      - name
+                      - namespace
+                      - relatedObjects
+                    properties:
+                      conditions:
+                        description: "conditions are used to communicate the state of the componentRoutes entry. \n Supported conditions include Available, Degraded and Progressing. \n If available is true, the content served by the route can be accessed by users. This includes cases where a default may continue to serve content while the customized route specified by the cluster-admin is being configured. \n If Degraded is true, that means something has gone wrong trying to handle the componentRoutes entry. The currentHostnames field may or may not be in effect. \n If Progressing is true, that means the component is taking some action related to the componentRoutes entry."
+                        type: array
+                        items:
+                          description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                          type: object
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              type: string
+                              format: date-time
+                            message:
+                              description: message is a human readable message indicating details about the transition. This may be an empty string.
+                              type: string
+                              maxLength: 32768
+                            observedGeneration:
+                              description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                              type: integer
+                              format: int64
+                              minimum: 0
+                            reason:
+                              description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                              type: string
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              type: string
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                              type: string
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      consumingUsers:
+                        description: consumingUsers is a slice of ServiceAccounts that need to have read permission on the servingCertKeyPairSecret secret.
+                        type: array
+                        maxItems: 5
+                        items:
+                          description: ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
+                          type: string
+                          maxLength: 512
+                          minLength: 1
+                          pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      currentHostnames:
+                        description: currentHostnames is the list of current names used by the route. Typically, this list should consist of a single hostname, but if multiple hostnames are supported by the route the operator may write multiple entries to this list.
+                        type: array
+                        minItems: 1
+                        items:
+                          description: "Hostname is an alias for hostname string validation. \n The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256. ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$ \n The right operand of the | is a new pattern that mimics the current API route admission validation on hostname, except that it allows hostnames longer than the maximum length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$ \n Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname was saved via validation by the incorrect left operand of the | operator."
+                          type: string
+                          pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      defaultHostname:
+                        description: defaultHostname is the hostname of this route prior to customization.
+                        type: string
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      name:
+                        description: "name is the logical name of the route to customize. It does not have to be the actual name of a route resource but it cannot be renamed. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 256
+                        minLength: 1
+                      namespace:
+                        description: "namespace is the namespace of the route to customize. It must be a real namespace. Using an actual namespace ensures that no two components will conflict and the same component can be installed multiple times. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      relatedObjects:
+                        description: relatedObjects is a list of resources which are useful when debugging or inspecting how spec.componentRoutes is applied.
+                        type: array
+                        minItems: 1
+                        items:
+                          description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                          type: object
+                          required:
+                            - group
+                            - name
+                            - resource
+                          properties:
+                            group:
+                              description: group of the referent.
+                              type: string
+                            name:
+                              description: name of the referent.
+                              type: string
+                            namespace:
+                              description: namespace of the referent.
+                              type: string
+                            resource:
+                              description: resource of the referent.
+                              type: string
+                  x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                  x-kubernetes-list-type: map
+                defaultPlacement:
+                  description: "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes. \n This field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments. \n See the documentation for the IngressController replicas and nodePlacement fields for more information. \n When omitted, the default value is Workers"
+                  type: string
+                  enum:
+                    - ControlPlane
+                    - Workers
+                    - ""
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/controllers/authorization/authorization_controller.go
+++ b/controllers/authorization/authorization_controller.go
@@ -96,6 +96,7 @@ func (r *PlatformAuthorizationReconciler) SetupWithManager(mgr ctrl.Manager) err
 		r.Client = mgr.GetClient()
 	}
 
+	// TODO(mvp): define predicates so we do not reconcile unnecessarily
 	//nolint:wrapcheck //reason there is no point in wrapping it
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(ctrlName+"-"+strings.ToLower(r.authComponent.CustomResourceType.Kind)).

--- a/controllers/authorization/authorization_controller_test.go
+++ b/controllers/authorization/authorization_controller_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Checking Authorization Resource Creation", test.EnvTest(), fun
 		Expect(err).ToNot(HaveOccurred())
 
 		var errCreate error
-		createdComponent, errCreate = test.CreateOrUpdateResource(ctx, envTest.Client, componentResource(resourceName, testNamespaceName))
+		createdComponent, errCreate = test.CreateResource(ctx, envTest.Client, componentResource(resourceName, testNamespaceName))
 		Expect(errCreate).ToNot(HaveOccurred())
 	})
 

--- a/controllers/routing/exported_svc_locator.go
+++ b/controllers/routing/exported_svc_locator.go
@@ -1,0 +1,38 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-platform/pkg/metadata"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getExportedService(ctx context.Context, cli client.Client, target *unstructured.Unstructured) (*corev1.Service, error) {
+	exportedSvcList := &corev1.ServiceList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(target.GetNamespace()),
+		client.MatchingLabels{metadata.Labels.RoutingExported: "true"},
+	}
+
+	if errList := cli.List(ctx, exportedSvcList, listOpts...); errList != nil {
+		return nil, fmt.Errorf("could not list exported services: %w", errList)
+	}
+
+	if len(exportedSvcList.Items) == 0 {
+		return nil, &NoExportedServicesError{Target: target}
+	}
+
+	return &exportedSvcList.Items[0], nil
+}
+
+// NoExportedServicesError represents a custom error type for missing exported services.
+type NoExportedServicesError struct {
+	Target client.Object
+}
+
+func (e *NoExportedServicesError) Error() string {
+	return fmt.Sprintf("no exported services found for target %s/%s (%s)", e.Target.GetNamespace(), e.Target.GetName(), e.Target.GetObjectKind().GroupVersionKind().String())
+}

--- a/controllers/routing/exported_svc_locator.go
+++ b/controllers/routing/exported_svc_locator.go
@@ -2,30 +2,50 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/opendatahub-io/odh-platform/pkg/metadata"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getExportedService(ctx context.Context, cli client.Client, target *unstructured.Unstructured) (*corev1.Service, error) {
-	exportedSvcList := &corev1.ServiceList{}
+func getExportedServices(ctx context.Context, cli client.Client, target *unstructured.Unstructured) ([]corev1.Service, error) {
+	ownerName := target.GetName()
+	ownerKind := target.GetObjectKind().GroupVersionKind().Kind
+
 	listOpts := []client.ListOption{
 		client.InNamespace(target.GetNamespace()),
-		client.MatchingLabels{metadata.Labels.RoutingExported: "true"},
+		// TODO(mvp): centralize label creation
+		client.MatchingLabels{
+			metadata.Labels.RoutingExported: "true",
+			metadata.Labels.OwnerName:       ownerName,
+			metadata.Labels.OwnerKind:       ownerKind,
+		},
 	}
 
-	if errList := cli.List(ctx, exportedSvcList, listOpts...); errList != nil {
-		return nil, fmt.Errorf("could not list exported services: %w", errList)
+	var exportedSvcList *corev1.ServiceList
+
+	// It is possible that the exported services are not yet created when we first receive CREATE event for watched CR
+	// and trigger reconcile. Retry to see if they show up in the cluster.
+	if errRetry := retry.OnError(retry.DefaultBackoff, isNoExportedServicesError, func() error {
+		exportedSvcList = &corev1.ServiceList{}
+		if errList := cli.List(ctx, exportedSvcList, listOpts...); errList != nil {
+			return fmt.Errorf("could not list exported services: %w", errList)
+		}
+
+		if len(exportedSvcList.Items) == 0 {
+			return &NoExportedServicesError{Target: target}
+		}
+
+		return nil
+	}); errRetry != nil {
+		return nil, fmt.Errorf("failed retrying to fetch exported services: %w", errRetry)
 	}
 
-	if len(exportedSvcList.Items) == 0 {
-		return nil, &NoExportedServicesError{Target: target}
-	}
-
-	return &exportedSvcList.Items[0], nil
+	return exportedSvcList.Items, nil
 }
 
 // NoExportedServicesError represents a custom error type for missing exported services.
@@ -35,4 +55,8 @@ type NoExportedServicesError struct {
 
 func (e *NoExportedServicesError) Error() string {
 	return fmt.Sprintf("no exported services found for target %s/%s (%s)", e.Target.GetNamespace(), e.Target.GetName(), e.Target.GetObjectKind().GroupVersionKind().String())
+}
+
+func isNoExportedServicesError(err error) bool {
+	return errors.Is(err, &NoExportedServicesError{})
 }

--- a/controllers/routing/routing_controller.go
+++ b/controllers/routing/routing_controller.go
@@ -22,7 +22,7 @@ import (
 
 const ctrlName = "routing"
 
-func NewPlatformRoutingReconciler(cli client.Client, log logr.Logger, component spi.RoutingComponent, config PlatformRoutingConfiguration) *PlatformRoutingReconciler {
+func NewPlatformRoutingReconciler(cli client.Client, log logr.Logger, component spi.RoutingComponent, config spi.PlatformRoutingConfiguration) *PlatformRoutingReconciler {
 	return &PlatformRoutingReconciler{
 		Client: cli,
 		log: log.WithValues(
@@ -41,14 +41,7 @@ type PlatformRoutingReconciler struct {
 	log            logr.Logger
 	component      spi.RoutingComponent
 	templateLoader spi.RoutingTemplateLoader
-	config         PlatformRoutingConfiguration
-}
-
-type PlatformRoutingConfiguration struct {
-	IngressSelectorLabel,
-	IngressSelectorValue,
-	IngressService,
-	GatewayNamespace string
+	config         spi.PlatformRoutingConfiguration
 }
 
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=*

--- a/controllers/routing/routing_controller_test.go
+++ b/controllers/routing/routing_controller_test.go
@@ -1,0 +1,578 @@
+package routing_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/opendatahub-io/odh-platform/pkg/metadata"
+	"github.com/opendatahub-io/odh-platform/test"
+	. "github.com/opendatahub-io/odh-platform/test/matchers"
+	openshiftroutev1 "github.com/openshift/api/route/v1"
+	"istio.io/client-go/pkg/apis/networking/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const watchedCR = `
+apiVersion: opendatahub.io/v1
+kind: Component
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  name: %[1]s
+`
+
+const domain = "opendatahub.io"
+
+var _ = Describe("Platform routing setup for the component", test.EnvTest(), func() {
+
+	var (
+		routerNs   *corev1.Namespace
+		appNs      *corev1.Namespace
+		deployment *appsv1.Deployment
+		svc        *corev1.Service
+
+		toRemove []client.Object
+	)
+
+	BeforeEach(func(ctx context.Context) {
+		routerNs = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: routingConfiguration.GatewayNamespace,
+			},
+		}
+		Expect(envTest.Client.Create(ctx, routerNs)).To(Succeed())
+
+		appNs = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-ns",
+			},
+		}
+		Expect(envTest.Client.Create(ctx, appNs)).To(Succeed())
+
+		config, errIngress := test.DefaultIngressControllerConfig(ctx, envTest.Client)
+		Expect(errIngress).ToNot(HaveOccurred())
+
+		deployment, svc = simpleSvcDeployment(ctx, appNs.Name, "mesh-service-name")
+
+		toRemove = []client.Object{routerNs, appNs, config, svc, deployment}
+
+	})
+
+	AfterEach(func(_ context.Context) {
+		envTest.DeleteAll(toRemove...)
+	})
+
+	When("watched component requests to expose service externally to the cluster", func() {
+
+		It("should have external routing resources created", func(ctx context.Context) {
+			// given
+			component, errCreate := test.CreateResource(ctx, envTest.Client,
+				componentResource("exported-test-component", appNs.Name))
+			Expect(errCreate).ToNot(HaveOccurred())
+			toRemove = append(toRemove, component)
+
+			// when
+			By("adding routing requirements on the resource and related svc", func() {
+				// routing.opendatahub.io/exported: "true"
+				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
+				// platform.opendatahub.io/owner-name: test-component
+				// platform.opendatahub.io/owner-kind: Component
+				ownerLabels := metadata.WithOwnerLabels(component)
+
+				// Service created by the component need to have these metadata added, i.e. by its controller
+				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
+					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
+				})
+				Expect(errExportSvc).ToNot(HaveOccurred())
+
+				// routing.opendatahub.io/export-mode: "external"
+				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "external")
+				_, errExportCR := controllerutil.CreateOrUpdate(
+					ctx, envTest.Client,
+					component,
+					func() error {
+						return metadata.ApplyMetaOptions(component, exposeExternally)
+					})
+				Expect(errExportCR).ToNot(HaveOccurred())
+			})
+
+			// then
+			Eventually(routeExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(ingressVirtualServiceExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+		})
+
+		It("should have new hosts propagated back to watched resource", func(ctx context.Context) {
+			// given
+			component, errCreate := test.CreateResource(ctx, envTest.Client,
+				componentResource("exported-test-component", appNs.Name))
+			Expect(errCreate).ToNot(HaveOccurred())
+			toRemove = append(toRemove, component)
+
+			// when
+			By("adding routing requirements on the watched resource and related svc", func() {
+				// routing.opendatahub.io/exported: "true"
+				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
+				// platform.opendatahub.io/owner-name: test-component
+				// platform.opendatahub.io/owner-kind: Component
+				ownerLabels := metadata.WithOwnerLabels(component)
+
+				// Service created by the component need to have these metadata added, i.e. by its controller
+				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
+					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
+				})
+				Expect(errExportSvc).ToNot(HaveOccurred())
+
+				// routing.opendatahub.io/export-mode: "external"
+				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "external")
+				_, errExportCR := controllerutil.CreateOrUpdate(
+					ctx, envTest.Client,
+					component,
+					func() error {
+						return metadata.ApplyMetaOptions(component, exposeExternally)
+					})
+				Expect(errExportCR).ToNot(HaveOccurred())
+			})
+
+			// then
+			Eventually(func(g Gomega, ctx context.Context) error {
+				updatedComponent := component.DeepCopy()
+				if errGet := envTest.Get(ctx, client.ObjectKeyFromObject(updatedComponent), updatedComponent); errGet != nil {
+					return errGet
+				}
+
+				g.Expect(updatedComponent).ToNot(HaveAnnotations(
+					metadata.Annotations.RoutingAddressesPublic, gstruct.Ignore(),
+				), "public services are not expected to be defined in this mode")
+
+				g.Expect(updatedComponent).To(HaveAnnotations(
+					metadata.Annotations.RoutingAddressesExternal, fmt.Sprintf("%s-%s.%s", svc.Name, svc.Namespace, domain),
+				))
+
+				return nil
+			}).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+		})
+
+	})
+
+	When("watched component requests to expose service locally (outside of service mesh) to the cluster", func() {
+
+		It("should have routing resources for out-of-mesh access created", func(ctx context.Context) {
+			// given
+			component, errCreate := test.CreateResource(ctx, envTest.Client,
+				componentResource("public-test-component", appNs.Name))
+			Expect(errCreate).ToNot(HaveOccurred())
+			toRemove = append(toRemove, component)
+
+			// when
+			By("adding routing requirements on the resource and related svc", func() {
+				// routing.opendatahub.io/exported: "true"
+				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
+				// platform.opendatahub.io/owner-name: test-component
+				// platform.opendatahub.io/owner-kind: Component
+				ownerLabels := metadata.WithOwnerLabels(component)
+
+				// Service created by the component need to have these metadata added, i.e. by its controller
+				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
+					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
+				})
+				Expect(errExportSvc).ToNot(HaveOccurred())
+
+				// routing.opendatahub.io/export-mode: "public"
+				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "public")
+				_, errExportCR := controllerutil.CreateOrUpdate(
+					ctx, envTest.Client,
+					component,
+					func() error {
+						return metadata.ApplyMetaOptions(component, exposeExternally)
+					})
+				Expect(errExportCR).ToNot(HaveOccurred())
+			})
+
+			// then
+			Eventually(publicSvcExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(publicGatewayExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(publicVirtualSvcExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+		})
+
+		It("should have new hosts propagated back to watched resource by the controller", func(ctx context.Context) {
+			// given
+			component, errCreate := test.CreateResource(ctx, envTest.Client,
+				componentResource("public-test-component", appNs.Name))
+			Expect(errCreate).ToNot(HaveOccurred())
+			toRemove = append(toRemove, component)
+
+			// when
+			By("adding routing requirements on the resource and related svc", func() {
+				// routing.opendatahub.io/exported: "true"
+				exportSvc := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
+				// platform.opendatahub.io/owner-name: test-component
+				// platform.opendatahub.io/owner-kind: Component
+				ownerLabels := metadata.WithOwnerLabels(component)
+
+				// Service created by the component need to have these metadata added, i.e. by its controller
+				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
+					return metadata.ApplyMetaOptions(svc, exportSvc, ownerLabels)
+				})
+				Expect(errExportSvc).ToNot(HaveOccurred())
+
+				// routing.opendatahub.io/export-mode: "public"
+				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "public")
+				_, errExportCR := controllerutil.CreateOrUpdate(
+					ctx, envTest.Client,
+					component,
+					func() error {
+						return metadata.ApplyMetaOptions(component, exposeExternally)
+					})
+				Expect(errExportCR).ToNot(HaveOccurred())
+			})
+
+			// then
+			Eventually(func(g Gomega, ctx context.Context) error {
+				updatedComponent := component.DeepCopy()
+				if errGet := envTest.Get(ctx, client.ObjectKeyFromObject(updatedComponent), updatedComponent); errGet != nil {
+					return errGet
+				}
+
+				g.Expect(updatedComponent).ToNot(
+					HaveAnnotations(
+						metadata.Annotations.RoutingAddressesExternal, gstruct.Ignore(),
+					), "public services are not expected to be defined in this mode")
+
+				g.Expect(updatedComponent).To(
+					HaveAnnotations(
+						metadata.Annotations.RoutingAddressesPublic,
+						fmt.Sprintf("%[1]s-%[2]s.%[3]s;%[1]s-%[2]s.%[3]s.svc;%[1]s-%[2]s.%[3]s.svc.cluster.local", svc.Name, svc.Namespace, routingConfiguration.GatewayNamespace),
+					),
+				)
+
+				return nil
+			}).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+		})
+
+	})
+
+	When("component requests to expose service both locally and externally to the cluster", func() {
+
+		It("should have both external and cluster-local resources created", func(ctx context.Context) {
+			// given
+			component, errCreate := test.CreateResource(ctx, envTest.Client,
+				componentResource("public-and-external-test-component", appNs.Name))
+			Expect(errCreate).ToNot(HaveOccurred())
+			toRemove = append(toRemove, component)
+
+			// when
+			By("adding routing requirements on the resource and related svc", func() {
+				// routing.opendatahub.io/exported: "true"
+				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
+				// platform.opendatahub.io/owner-name: test-component
+				// platform.opendatahub.io/owner-kind: Component
+				ownerLabels := metadata.WithOwnerLabels(component)
+
+				// Service created by the component need to have these metadata added, i.e. by its controller
+				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
+					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
+				})
+				Expect(errExportSvc).ToNot(HaveOccurred())
+
+				// routing.opendatahub.io/export-mode: "public;external"
+				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "public;external")
+				_, errExportCR := controllerutil.CreateOrUpdate(
+					ctx, envTest.Client,
+					component,
+					func() error {
+						return metadata.ApplyMetaOptions(component, exposeExternally)
+					})
+				Expect(errExportCR).ToNot(HaveOccurred())
+			})
+
+			// then
+			Eventually(routeExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(ingressVirtualServiceExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(publicSvcExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(publicVirtualSvcExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(publicGatewayExistsFor(svc)).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+			Eventually(func(g Gomega, ctx context.Context) error {
+				updatedComponent := component.DeepCopy()
+				if errGet := envTest.Get(ctx, client.ObjectKeyFromObject(updatedComponent), updatedComponent); errGet != nil {
+					return errGet
+				}
+
+				g.Expect(updatedComponent).To(
+					HaveAnnotations(
+						metadata.Annotations.RoutingAddressesExternal,
+						fmt.Sprintf("%s-%s.%s", svc.Name, svc.Namespace, domain),
+						metadata.Annotations.RoutingAddressesPublic,
+						fmt.Sprintf("%[1]s-%[2]s.%[3]s;%[1]s-%[2]s.%[3]s.svc;%[1]s-%[2]s.%[3]s.svc.cluster.local", svc.Name, svc.Namespace, routingConfiguration.GatewayNamespace),
+					),
+				)
+
+				return nil
+			}).
+				WithContext(ctx).
+				WithTimeout(test.DefaultTimeout).
+				WithPolling(test.DefaultPolling).
+				Should(Succeed())
+
+		})
+
+	})
+
+	PWhen("component is deleted all routing resources should be removed", func() {
+
+	})
+
+})
+
+func simpleSvcDeployment(ctx context.Context, nsName, svcName string) (*appsv1.Deployment, *corev1.Service) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: nsName,
+			Labels: map[string]string{
+				"app":     svcName,
+				"service": svcName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": svcName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       8080,
+					TargetPort: intstr.FromInt32(8000),
+				},
+			},
+		},
+	}
+
+	Expect(envTest.Create(ctx, service)).To(Succeed())
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: nsName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To[int32](1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":     svcName,
+					"version": "v1",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "true",
+					},
+					Labels: map[string]string{
+						"app":     svcName,
+						"version": "v1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: svcName,
+					Containers: []corev1.Container{
+						{
+							Name:  "httpbin",
+							Image: "kennethreitz/httpbin",
+							Command: []string{
+								"gunicorn", "--access-logfile", "-", "-b", "[::]:8000", "httpbin:app",
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	Expect(envTest.Create(ctx, deployment)).To(Succeed())
+
+	return deployment, service
+}
+
+func routeExistsFor(exportedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
+	return func(g Gomega, ctx context.Context) error {
+		svcRoute := &openshiftroutev1.Route{}
+		if errGet := envTest.Get(ctx, types.NamespacedName{
+			Name:      exportedSvc.Name + "-" + exportedSvc.Namespace + "-route",
+			Namespace: routingConfiguration.GatewayNamespace,
+		}, svcRoute); errGet != nil {
+			return errGet
+		}
+
+		g.Expect(svcRoute).To(BeAttachedToService(routingConfiguration.IngressService))
+		g.Expect(svcRoute).To(HaveHost(exportedSvc.Name + "-" + exportedSvc.Namespace + "." + domain))
+
+		return nil
+	}
+}
+
+func publicSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
+	return func(g Gomega, ctx context.Context) error {
+		publicSvc := &corev1.Service{}
+		if errGet := envTest.Get(ctx, types.NamespacedName{
+			Name:      exposedSvc.Name + "-" + exposedSvc.Namespace,
+			Namespace: routingConfiguration.GatewayNamespace,
+		}, publicSvc); errGet != nil {
+			return errGet
+		}
+
+		g.Expect(publicSvc).To(
+			HaveAnnotations(
+				"service.beta.openshift.io/serving-cert-secret-name",
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"-certs",
+			),
+		)
+		g.Expect(publicSvc.Spec.Selector).To(
+			HaveKeyWithValue(routingConfiguration.IngressSelectorLabel, routingConfiguration.IngressSelectorValue),
+		)
+
+		return nil
+	}
+}
+
+func publicGatewayExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
+	return func(g Gomega, ctx context.Context) error {
+		publicGateway := &v1beta1.Gateway{}
+		if errGet := envTest.Get(ctx, types.NamespacedName{
+			Name:      exposedSvc.Name + "-" + exposedSvc.Namespace,
+			Namespace: routingConfiguration.GatewayNamespace,
+		}, publicGateway); errGet != nil {
+			return errGet
+		}
+
+		g.Expect(publicGateway.Spec.GetSelector()).To(HaveKeyWithValue(routingConfiguration.IngressSelectorLabel, routingConfiguration.IngressSelectorValue))
+		// limitation: only checks first element of []*Server slice
+		g.Expect(publicGateway).To(
+			HaveHosts(
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"."+routingConfiguration.GatewayNamespace,
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"."+routingConfiguration.GatewayNamespace+".svc",
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"."+routingConfiguration.GatewayNamespace+".svc.cluster.local",
+			),
+		)
+
+		return nil
+	}
+}
+
+func publicVirtualSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
+	return func(g Gomega, ctx context.Context) error {
+		publicVS := &v1beta1.VirtualService{}
+		if errGet := envTest.Get(ctx, types.NamespacedName{
+			Name:      exposedSvc.Name + "-" + exposedSvc.Namespace,
+			Namespace: routingConfiguration.GatewayNamespace,
+		}, publicVS); errGet != nil {
+			return errGet
+		}
+
+		g.Expect(publicVS).To(
+			HaveHosts(
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"."+routingConfiguration.GatewayNamespace,
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"."+routingConfiguration.GatewayNamespace+".svc",
+				exposedSvc.Name+"-"+exposedSvc.Namespace+"."+routingConfiguration.GatewayNamespace+".svc.cluster.local",
+			),
+		)
+		g.Expect(publicVS).To(BeAttachedToGateways("mesh", exposedSvc.Name+"-"+exposedSvc.Namespace))
+		g.Expect(publicVS).To(RouteToHost(exposedSvc.Name+"."+exposedSvc.Namespace+".svc.cluster.local", 8000))
+
+		return nil
+	}
+}
+
+func ingressVirtualServiceExistsFor(exportedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
+	return func(g Gomega, ctx context.Context) error {
+		routerVS := &v1beta1.VirtualService{}
+		if errGet := envTest.Get(ctx, types.NamespacedName{
+			Name:      exportedSvc.Name + "-" + exportedSvc.Namespace + "-ingress",
+			Namespace: routingConfiguration.GatewayNamespace,
+		}, routerVS); errGet != nil {
+			return errGet
+		}
+
+		g.Expect(routerVS).To(HaveHost(exportedSvc.Name + "-" + exportedSvc.Namespace + "." + domain))
+		g.Expect(routerVS).To(BeAttachedToGateways(routingConfiguration.IngressService))
+		g.Expect(routerVS).To(RouteToHost(exportedSvc.Name+"."+exportedSvc.Namespace+".svc.cluster.local", 8000))
+
+		return nil
+	}
+}
+
+func componentResource(name, namespace string) []byte {
+	return []byte(fmt.Sprintf(watchedCR, name, namespace))
+}

--- a/controllers/routing/routing_controller_test.go
+++ b/controllers/routing/routing_controller_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gstruct"
 	"github.com/opendatahub-io/odh-platform/pkg/metadata"
 	"github.com/opendatahub-io/odh-platform/test"
 	. "github.com/opendatahub-io/odh-platform/test/matchers"
@@ -162,11 +161,11 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 					return errGet
 				}
 
-				g.Expect(updatedComponent).ToNot(HaveAnnotations(
-					metadata.Annotations.RoutingAddressesPublic, gstruct.Ignore(),
+				g.Expect(updatedComponent.GetAnnotations()).ToNot(HaveKey(
+					metadata.Annotations.RoutingAddressesPublic,
 				), "public services are not expected to be defined in this mode")
 
-				g.Expect(updatedComponent).To(HaveAnnotations(
+				g.Expect(updatedComponent.GetAnnotations()).To(HaveKeyWithValue(
 					metadata.Annotations.RoutingAddressesExternal, fmt.Sprintf("%s-%s.%s", svc.Name, svc.Namespace, domain),
 				))
 
@@ -280,13 +279,13 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 					return errGet
 				}
 
-				g.Expect(updatedComponent).ToNot(
-					HaveAnnotations(
-						metadata.Annotations.RoutingAddressesExternal, gstruct.Ignore(),
+				g.Expect(updatedComponent.GetAnnotations()).ToNot(
+					HaveKey(
+						metadata.Annotations.RoutingAddressesExternal,
 					), "public services are not expected to be defined in this mode")
 
-				g.Expect(updatedComponent).To(
-					HaveAnnotations(
+				g.Expect(updatedComponent.GetAnnotations()).To(
+					HaveKeyWithValue(
 						metadata.Annotations.RoutingAddressesPublic,
 						fmt.Sprintf("%[1]s-%[2]s.%[3]s;%[1]s-%[2]s.%[3]s.svc;%[1]s-%[2]s.%[3]s.svc.cluster.local", svc.Name, svc.Namespace, routingConfiguration.GatewayNamespace),
 					),
@@ -379,12 +378,16 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 					return errGet
 				}
 
-				g.Expect(updatedComponent).To(
-					HaveAnnotations(
-						metadata.Annotations.RoutingAddressesExternal,
-						fmt.Sprintf("%s-%s.%s", svc.Name, svc.Namespace, domain),
-						metadata.Annotations.RoutingAddressesPublic,
-						fmt.Sprintf("%[1]s-%[2]s.%[3]s;%[1]s-%[2]s.%[3]s.svc;%[1]s-%[2]s.%[3]s.svc.cluster.local", svc.Name, svc.Namespace, routingConfiguration.GatewayNamespace),
+				g.Expect(updatedComponent.GetAnnotations()).To(
+					And(
+						HaveKeyWithValue(
+							metadata.Annotations.RoutingAddressesExternal,
+							fmt.Sprintf("%s-%s.%s", svc.Name, svc.Namespace, domain),
+						),
+						HaveKeyWithValue(
+							metadata.Annotations.RoutingAddressesPublic,
+							fmt.Sprintf("%[1]s-%[2]s.%[3]s;%[1]s-%[2]s.%[3]s.svc;%[1]s-%[2]s.%[3]s.svc.cluster.local", svc.Name, svc.Namespace, routingConfiguration.GatewayNamespace),
+						),
 					),
 				)
 
@@ -506,12 +509,13 @@ func publicSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.C
 			return errGet
 		}
 
-		g.Expect(publicSvc).To(
-			HaveAnnotations(
+		g.Expect(publicSvc.GetAnnotations()).To(
+			HaveKeyWithValue(
 				"service.beta.openshift.io/serving-cert-secret-name",
 				exposedSvc.Name+"-"+exposedSvc.Namespace+"-certs",
 			),
 		)
+
 		g.Expect(publicSvc.Spec.Selector).To(
 			HaveKeyWithValue(routingConfiguration.IngressSelectorLabel, routingConfiguration.IngressSelectorValue),
 		)

--- a/controllers/routing/routing_controller_test.go
+++ b/controllers/routing/routing_controller_test.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -82,29 +83,17 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 			Expect(errCreate).ToNot(HaveOccurred())
 			toRemove = append(toRemove, component)
 
-			// when
-			By("adding routing requirements on the resource and related svc", func() {
-				// routing.opendatahub.io/exported: "true"
-				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
-				// platform.opendatahub.io/owner-name: test-component
-				// platform.opendatahub.io/owner-kind: Component
-				ownerLabels := metadata.WithOwnerLabels(component)
+			// when routing through platform mesh
+			By("adding component service to platform routing", func() {
+				// required annotation for watched custom resource:
+				// 	routing.opendatahub.io/export-mode: "external"
+				exportCustomResource(ctx, component, "external")
 
-				// Service created by the component need to have these metadata added, i.e. by its controller
-				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
-					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
-				})
-				Expect(errExportSvc).ToNot(HaveOccurred())
-
-				// routing.opendatahub.io/export-mode: "external"
-				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "external")
-				_, errExportCR := controllerutil.CreateOrUpdate(
-					ctx, envTest.Client,
-					component,
-					func() error {
-						return metadata.ApplyMetaOptions(component, exposeExternally)
-					})
-				Expect(errExportCR).ToNot(HaveOccurred())
+				// required labels for the exported service:
+				// 	routing.opendatahub.io/exported: "true"
+				// 	platform.opendatahub.io/owner-name: test-component
+				// 	platform.opendatahub.io/owner-kind: Component
+				addRoutingRequirementsToSvc(ctx, svc, component)
 			})
 
 			// then
@@ -129,29 +118,17 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 			Expect(errCreate).ToNot(HaveOccurred())
 			toRemove = append(toRemove, component)
 
-			// when
-			By("adding routing requirements on the watched resource and related svc", func() {
-				// routing.opendatahub.io/exported: "true"
-				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
-				// platform.opendatahub.io/owner-name: test-component
-				// platform.opendatahub.io/owner-kind: Component
-				ownerLabels := metadata.WithOwnerLabels(component)
+			// when routing through platform mesh
+			By("adding component service to platform routing", func() {
+				// required annotation for watched custom resource:
+				// 	routing.opendatahub.io/export-mode: "external"
+				exportCustomResource(ctx, component, "external")
 
-				// Service created by the component need to have these metadata added, i.e. by its controller
-				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
-					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
-				})
-				Expect(errExportSvc).ToNot(HaveOccurred())
-
-				// routing.opendatahub.io/export-mode: "external"
-				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "external")
-				_, errExportCR := controllerutil.CreateOrUpdate(
-					ctx, envTest.Client,
-					component,
-					func() error {
-						return metadata.ApplyMetaOptions(component, exposeExternally)
-					})
-				Expect(errExportCR).ToNot(HaveOccurred())
+				// required labels for the exported service:
+				// 	routing.opendatahub.io/exported: "true"
+				// 	platform.opendatahub.io/owner-name: test-component
+				// 	platform.opendatahub.io/owner-kind: Component
+				addRoutingRequirementsToSvc(ctx, svc, component)
 			})
 
 			// then
@@ -188,29 +165,17 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 			Expect(errCreate).ToNot(HaveOccurred())
 			toRemove = append(toRemove, component)
 
-			// when
-			By("adding routing requirements on the resource and related svc", func() {
-				// routing.opendatahub.io/exported: "true"
-				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
-				// platform.opendatahub.io/owner-name: test-component
-				// platform.opendatahub.io/owner-kind: Component
-				ownerLabels := metadata.WithOwnerLabels(component)
+			// when routing through platform mesh
+			By("adding component service to platform routing", func() {
+				// required annotation for watched custom resource:
+				// 	routing.opendatahub.io/export-mode: "public"
+				exportCustomResource(ctx, component, "public")
 
-				// Service created by the component need to have these metadata added, i.e. by its controller
-				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
-					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
-				})
-				Expect(errExportSvc).ToNot(HaveOccurred())
-
-				// routing.opendatahub.io/export-mode: "public"
-				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "public")
-				_, errExportCR := controllerutil.CreateOrUpdate(
-					ctx, envTest.Client,
-					component,
-					func() error {
-						return metadata.ApplyMetaOptions(component, exposeExternally)
-					})
-				Expect(errExportCR).ToNot(HaveOccurred())
+				// required labels for the exported service:
+				// 	routing.opendatahub.io/exported: "true"
+				// 	platform.opendatahub.io/owner-name: test-component
+				// 	platform.opendatahub.io/owner-kind: Component
+				addRoutingRequirementsToSvc(ctx, svc, component)
 			})
 
 			// then
@@ -247,29 +212,17 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 			Expect(errCreate).ToNot(HaveOccurred())
 			toRemove = append(toRemove, component)
 
-			// when
-			By("adding routing requirements on the resource and related svc", func() {
-				// routing.opendatahub.io/exported: "true"
-				exportSvc := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
-				// platform.opendatahub.io/owner-name: test-component
-				// platform.opendatahub.io/owner-kind: Component
-				ownerLabels := metadata.WithOwnerLabels(component)
+			// when routing through platform mesh
+			By("adding component service to platform routing", func() {
+				// required annotation for watched custom resource:
+				// 	routing.opendatahub.io/export-mode: "public"
+				exportCustomResource(ctx, component, "public")
 
-				// Service created by the component need to have these metadata added, i.e. by its controller
-				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
-					return metadata.ApplyMetaOptions(svc, exportSvc, ownerLabels)
-				})
-				Expect(errExportSvc).ToNot(HaveOccurred())
-
-				// routing.opendatahub.io/export-mode: "public"
-				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "public")
-				_, errExportCR := controllerutil.CreateOrUpdate(
-					ctx, envTest.Client,
-					component,
-					func() error {
-						return metadata.ApplyMetaOptions(component, exposeExternally)
-					})
-				Expect(errExportCR).ToNot(HaveOccurred())
+				// required labels for the exported service:
+				// 	routing.opendatahub.io/exported: "true"
+				// 	platform.opendatahub.io/owner-name: test-component
+				// 	platform.opendatahub.io/owner-kind: Component
+				addRoutingRequirementsToSvc(ctx, svc, component)
 			})
 
 			// then
@@ -310,29 +263,17 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 			Expect(errCreate).ToNot(HaveOccurred())
 			toRemove = append(toRemove, component)
 
-			// when
-			By("adding routing requirements on the resource and related svc", func() {
-				// routing.opendatahub.io/exported: "true"
-				exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
-				// platform.opendatahub.io/owner-name: test-component
-				// platform.opendatahub.io/owner-kind: Component
-				ownerLabels := metadata.WithOwnerLabels(component)
+			// when routing through platform mesh
+			By("adding component service to platform routing", func() {
+				// required annotation for watched custom resource:
+				// 	routing.opendatahub.io/export-mode: "public;external"
+				exportCustomResource(ctx, component, "public;external")
 
-				// Service created by the component need to have these metadata added, i.e. by its controller
-				_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, svc, func() error {
-					return metadata.ApplyMetaOptions(svc, exportAnnotation, ownerLabels)
-				})
-				Expect(errExportSvc).ToNot(HaveOccurred())
-
-				// routing.opendatahub.io/export-mode: "public;external"
-				exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, "public;external")
-				_, errExportCR := controllerutil.CreateOrUpdate(
-					ctx, envTest.Client,
-					component,
-					func() error {
-						return metadata.ApplyMetaOptions(component, exposeExternally)
-					})
-				Expect(errExportCR).ToNot(HaveOccurred())
+				// required labels for the exported service:
+				// 	routing.opendatahub.io/exported: "true"
+				// 	platform.opendatahub.io/owner-name: test-component
+				// 	platform.opendatahub.io/owner-kind: Component
+				addRoutingRequirementsToSvc(ctx, svc, component)
 			})
 
 			// then
@@ -407,6 +348,35 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 	})
 
 })
+
+func exportCustomResource(ctx context.Context, exportedComponent *unstructured.Unstructured, mode string) {
+	// routing.opendatahub.io/export-mode: "public;external"
+	exposeExternally := metadata.WithAnnotations(metadata.Annotations.RoutingExportMode, mode)
+	_, errExportCR := controllerutil.CreateOrUpdate(
+		ctx, envTest.Client,
+		exportedComponent,
+		func() error {
+			return metadata.ApplyMetaOptions(exportedComponent, exposeExternally)
+		})
+	Expect(errExportCR).ToNot(HaveOccurred())
+}
+
+func addRoutingRequirementsToSvc(ctx context.Context, exportedSvc *corev1.Service, owningComponent *unstructured.Unstructured) {
+	// routing.opendatahub.io/exported: "true"
+	exportAnnotation := metadata.WithLabels(metadata.Labels.RoutingExported, "true")
+	// platform.opendatahub.io/owner-name: test-component
+	// platform.opendatahub.io/owner-kind: Component
+	ownerLabels := metadata.WithLabels(
+		metadata.Labels.OwnerName, owningComponent.GetName(),
+		metadata.Labels.OwnerKind, owningComponent.GetKind(),
+	)
+
+	// Service created by the component need to have these metadata added, i.e. by its controller
+	_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, exportedSvc, func() error {
+		return metadata.ApplyMetaOptions(exportedSvc, exportAnnotation, ownerLabels)
+	})
+	Expect(errExportSvc).ToNot(HaveOccurred())
+}
 
 func routeExistsFor(exportedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {

--- a/controllers/routing/routing_reconcile_resources.go
+++ b/controllers/routing/routing_reconcile_resources.go
@@ -2,41 +2,122 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
-	"github.com/opendatahub-io/odh-platform/pkg/config"
+	"github.com/opendatahub-io/odh-platform/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform/pkg/metadata"
 	"github.com/opendatahub-io/odh-platform/pkg/spi"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 func (r *PlatformRoutingReconciler) reconcileResources(ctx context.Context, target *unstructured.Unstructured) error {
-	exportMode, exportModeFound := target.GetAnnotations()[metadata.Annotations.RoutingExportMode]
+	exportModes, exportModeFound := extractExportModes(target)
+	// TODO shouldn't we make it a predicate for ctrl watch instead?
 	if !exportModeFound {
 		return nil
 	}
 
-	// TODO: lookup service owned by target with "ExportableService" annotation
-	// TODO: use label instead, then we could do a service label search?
-	// routing.opendatahub.io/exposable=true && app.kubernetes.io/part-of=target.Name
+	r.log.Info("Reconciling resources for target", "target", target)
 
-	templateData := spi.RoutingTemplateData{
-		PublicServiceName: "registry-office", // TODO: serviceName - serviceNamespace
-		ServiceName:       "registry",        // TODO: lookupService.GetName()
-		ServiceNamespace:  target.GetNamespace(),
-		GatewayNamespace:  config.GetGatewayNamespace(),
-		Domain:            "app-crc.testing", // TODO: Read from where?
+	exportedSvc, errSvcGet := getExportedService(ctx, r.Client, target)
+	if errSvcGet != nil {
+		if errors.Is(errSvcGet, &NoExportedServicesError{}) {
+			r.log.Info("no exported service found for target", "target", target)
 
-		IngressSelectorLabel: config.GetIngressSelectorKey(),
-		IngressSelectorValue: config.GetIngressSelectorValue(),
-		IngressService:       config.GetGatewayService(),
+			return nil
+		}
+
+		return errSvcGet
 	}
 
-	targetKey := types.NamespacedName{Namespace: target.GetNamespace(), Name: target.GetName()}
-	if _, err := r.templateLoader.Load(ctx, spi.RouteType(exportMode), targetKey, templateData); err != nil {
-		return fmt.Errorf("could not load templates for type %s: %w", exportMode, err)
+	domain, errDomain := cluster.GetDomain(ctx, r.Client)
+	if errDomain != nil {
+		return fmt.Errorf("could not get domain: %w", errDomain)
+	}
+
+	templateData := spi.RoutingTemplateData{
+		PublicServiceName: exportedSvc.GetName() + "-" + exportedSvc.GetNamespace(),
+		ServiceName:       exportedSvc.GetName(),
+		ServiceNamespace:  exportedSvc.GetNamespace(),
+		ServiceTargetPort: exportedSvc.Spec.Ports[0].TargetPort.String(),
+		Domain:            domain,
+		// TODO: compose instead
+		IngressSelectorLabel: r.config.IngressSelectorLabel,
+		IngressSelectorValue: r.config.IngressSelectorValue,
+		IngressService:       r.config.IngressService,
+		GatewayNamespace:     r.config.GatewayNamespace,
+	}
+
+	withOwnershipLabels := ownershipLabels(target)
+
+	targetKey := k8stypes.NamespacedName{Namespace: target.GetNamespace(), Name: target.GetName()}
+
+	for _, exportMode := range exportModes {
+		resources, err := r.templateLoader.Load(ctx, exportMode, targetKey, templateData)
+		if err != nil {
+			return fmt.Errorf("could not load templates for type %s: %w", exportMode, err)
+		}
+
+		if errApply := cluster.Apply(ctx, r.Client, resources, withOwnershipLabels...); errApply != nil {
+			return fmt.Errorf("could not apply routing resources for type %s: %w", exportMode, errApply)
+		}
+	}
+
+	return propagateHostsToWatchedCR(target, templateData)
+}
+
+func propagateHostsToWatchedCR(target *unstructured.Unstructured, data spi.RoutingTemplateData) error {
+	var metaOptions []metadata.Options
+
+	exportModes, found := extractExportModes(target)
+	if !found {
+		return fmt.Errorf("could not extract export modes from target %s", target.GetName())
+	}
+
+	// TODO(mvp) : put the logic of creating host names into a single place
+	for _, exportMode := range exportModes {
+		switch exportMode {
+		case spi.ExternalRoute:
+			externalAddress := metadata.WithAnnotations(metadata.Annotations.RoutingAddressesExternal, fmt.Sprintf("%s-%s.%s", data.ServiceName, data.ServiceNamespace, data.Domain))
+			metaOptions = append(metaOptions, externalAddress)
+		case spi.PublicRoute:
+			publicAddresses := metadata.WithAnnotations(
+				metadata.Annotations.RoutingAddressesPublic,
+				fmt.Sprintf("%[1]s.%[2]s;%[1]s.%[2]s.svc;%[1]s.%[2]s.svc.cluster.local", data.PublicServiceName, data.GatewayNamespace),
+			)
+			metaOptions = append(metaOptions, publicAddresses)
+		}
+	}
+
+	if errApply := metadata.ApplyMetaOptions(target, metaOptions...); errApply != nil {
+		return fmt.Errorf("could not propagate hosts back to target %s/%s : %w", target.GetObjectKind().GroupVersionKind().Kind, target.GetName(), errApply)
 	}
 
 	return nil
+}
+
+func ownershipLabels(target *unstructured.Unstructured) []metadata.Options {
+	return []metadata.Options{
+		metadata.WithOwnerLabels(target),
+		metadata.WithLabels(metadata.Labels.AppManagedBy, "odh-routing-controller"),
+	}
+}
+
+func extractExportModes(target *unstructured.Unstructured) ([]spi.RouteType, bool) {
+	exportModes, exportModeFound := target.GetAnnotations()[metadata.Annotations.RoutingExportMode]
+	if !exportModeFound {
+		return nil, false
+	}
+
+	exportModesSplit := strings.Split(exportModes, ";")
+	routeTypes := make([]spi.RouteType, len(exportModesSplit))
+
+	for i, exportMode := range exportModesSplit {
+		routeTypes[i] = spi.RouteType(exportMode)
+	}
+
+	return routeTypes, true
 }

--- a/controllers/routing/routing_reconcile_resources.go
+++ b/controllers/routing/routing_reconcile_resources.go
@@ -25,7 +25,7 @@ func (r *PlatformRoutingReconciler) reconcileResources(ctx context.Context, targ
 
 	exportedServices, errSvcGet := getExportedServices(ctx, r.Client, target)
 	if errSvcGet != nil {
-		if errors.Is(errSvcGet, &NoExportedServicesError{}) {
+		if errors.Is(errSvcGet, &ExportedServiceNotFoundError{}) {
 			r.log.Info("no exported services found for target", "target", target)
 
 			return nil

--- a/controllers/routing/suite_test.go
+++ b/controllers/routing/suite_test.go
@@ -1,0 +1,64 @@
+package routing_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opendatahub-io/odh-platform/controllers/routing"
+	"github.com/opendatahub-io/odh-platform/pkg/spi"
+	"github.com/opendatahub-io/odh-platform/test"
+	"github.com/opendatahub-io/odh-platform/test/k8senvtest"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	envTest              *k8senvtest.Client
+	routingConfiguration = routing.PlatformRoutingConfiguration{
+		IngressService:       "odh-router",
+		GatewayNamespace:     "odh-gateway",
+		IngressSelectorLabel: "istio",
+		IngressSelectorValue: "opendatahub-ingress-gateway",
+	}
+
+	cancel context.CancelFunc
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Routing reconciliation")
+}
+
+var _ = SynchronizedBeforeSuite(func() {
+	if !test.IsEnvTest() {
+		return
+	}
+
+	routingCtrl := routing.NewPlatformRoutingReconciler(
+		nil,
+		ctrl.Log.WithName("controllers").WithName("platform"),
+		spi.RoutingComponent{
+			CustomResourceType: spi.ResourceSchema{
+				GroupVersionKind: schema.GroupVersionKind{
+					Version: "v1",
+					Group:   "opendatahub.io",
+					Kind:    "Component",
+				},
+			},
+		},
+		routingConfiguration,
+	)
+
+	envTest, cancel = test.StartWithControllers(routingCtrl.SetupWithManager)
+}, func() {})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	if !test.IsEnvTest() {
+		return
+	}
+	By("Tearing down the test environment")
+	cancel()
+	Expect(envTest.Stop()).To(Succeed())
+})

--- a/controllers/routing/suite_test.go
+++ b/controllers/routing/suite_test.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	envTest              *k8senvtest.Client
-	routingConfiguration = routing.PlatformRoutingConfiguration{
+	routingConfiguration = spi.PlatformRoutingConfiguration{
 		IngressService:       "odh-router",
 		GatewayNamespace:     "odh-gateway",
 		IngressSelectorLabel: "istio",

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3
 	k8s.io/code-generator v0.28.3
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/controller-tools v0.9.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 // Testing deps
@@ -91,8 +93,6 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	routingConfig := routing.PlatformRoutingConfiguration{
+	routingConfig := spi.PlatformRoutingConfiguration{
 		IngressSelectorLabel: config.GetIngressSelectorKey(),
 		IngressSelectorValue: config.GetIngressSelectorValue(),
 		IngressService:       config.GetGatewayService(),

--- a/pkg/cluster/ingress.go
+++ b/pkg/cluster/ingress.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetDomain(ctx context.Context, cli client.Client) (string, error) {
+	ingress := &unstructured.Unstructured{}
+	ingress.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "Ingress",
+	})
+
+	if err := cli.Get(ctx, client.ObjectKey{
+		Namespace: "",
+		Name:      "cluster",
+	}, ingress); err != nil {
+		return "", fmt.Errorf("failed fetching cluster's ingress details: %w", err)
+	}
+
+	domain, found, err := unstructured.NestedString(ingress.Object, "spec", "domain")
+
+	if !found {
+		return "", errors.New("spec.domain not found in cluster's ingress")
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("failed reading spec.domain in cluster's ingress: %w", err)
+	}
+
+	return domain, nil
+}

--- a/pkg/cluster/unstruct.go
+++ b/pkg/cluster/unstruct.go
@@ -1,0 +1,63 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-platform/pkg/metadata"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Apply(ctx context.Context, cli client.Client, objects []*unstructured.Unstructured, metaOptions ...metadata.Options) error {
+	for _, source := range objects {
+		for _, opt := range metaOptions {
+			if err := opt(source); err != nil {
+				return err
+			}
+		}
+
+		target := source.DeepCopy()
+
+		name := source.GetName()
+		namespace := source.GetNamespace()
+
+		errGet := cli.Get(ctx, k8stypes.NamespacedName{Name: name, Namespace: namespace}, target)
+		if client.IgnoreNotFound(errGet) != nil {
+			return fmt.Errorf("failed to get resource %s/%s: %w", namespace, name, errGet)
+		}
+
+		if k8serr.IsNotFound(errGet) {
+			if errCreate := cli.Create(ctx, target); client.IgnoreAlreadyExists(errCreate) != nil { //nolint:gocritic //reason: we don't want to treat AlreadyExists as error here
+				return fmt.Errorf("failed to create source %s/%s: %w", namespace, name, errCreate)
+			}
+		} else {
+			if errUpdate := patchUsingApplyStrategy(ctx, cli, source, target); errUpdate != nil {
+				return fmt.Errorf("failed to reconcile resource %s/%s: %w", namespace, name, errUpdate)
+			}
+		}
+	}
+
+	return nil
+}
+
+// patchUsingApplyStrategy performs server-side apply [1] patch to a Kubernetes resource.
+// It treats the provided source as the desired state of the resource and attempts to
+// reconcile the target resource to match this state. The function takes ownership of the
+// fields specified in the target and will ensure they match desired state.
+//
+// [1] https://kubernetes.io/docs/reference/using-api/server-side-apply/
+func patchUsingApplyStrategy(ctx context.Context, cli client.Client, source, target *unstructured.Unstructured) error {
+	data, errJSON := source.MarshalJSON()
+	if errJSON != nil {
+		return fmt.Errorf("error converting yaml to json: %w", errJSON)
+	}
+
+	if errPatch := cli.Patch(ctx, target, client.RawPatch(k8stypes.ApplyPatchType, data), client.ForceOwnership, client.FieldOwner("odh-platform")); errPatch != nil {
+		return fmt.Errorf("failed to apply patch to %s: %w", source.GroupVersionKind().String(), errPatch)
+	}
+
+	return nil
+}

--- a/pkg/metadata/annotation.go
+++ b/pkg/metadata/annotation.go
@@ -10,6 +10,6 @@ var Annotations = struct { //nolint:gochecknoglobals //reason: anonymous struct 
 	AuthEnabled:              "security.opendatahub.io/enable-auth",
 	AuthorizationGroup:       "security.opendatahub.io/authorization-group",
 	RoutingExportMode:        "routing.opendatahub.io/export-mode",
-	RoutingAddressesPublic:   "routing.opendatahub.io/addresses-public",
-	RoutingAddressesExternal: "routing.opendatahub.io/addresses-external",
+	RoutingAddressesPublic:   "routing.opendatahub.io/public-addresses",
+	RoutingAddressesExternal: "routing.opendatahub.io/external-addresses",
 }

--- a/pkg/metadata/label.go
+++ b/pkg/metadata/label.go
@@ -8,10 +8,13 @@ var Labels = struct { //nolint:gochecknoglobals //reason: anonymous struct is us
 	AppName      string
 	AppVersion   string
 	AppManagedBy string
-	// OwnerName is the name of the owner of the resource combined with its namespace separated by a dash if applicable.
+	// OwnerName is the name of the owner of the resource.
 	OwnerName string
 	// OwnerKind is the kind of the owner of the resource.
-	OwnerKind       string
+	OwnerKind string
+	// OwnerUID is the UID of the owner of the resource. It is internally set by the platform
+	// to enable accurate garbage collection of the resources cross-namespace.
+	OwnerUID        string
 	RoutingExported string
 }{
 	AppPartOf:       "app.kubernetes.io/part-of",
@@ -21,6 +24,7 @@ var Labels = struct { //nolint:gochecknoglobals //reason: anonymous struct is us
 	AppManagedBy:    "app.kubernetes.io/managed-by",
 	OwnerName:       "platform.opendatahub.io/owner-name",
 	OwnerKind:       "platform.opendatahub.io/owner-kind",
+	OwnerUID:        "platform.opendatahub.io/owner-uid",
 	RoutingExported: "routing.opendatahub.io/exported",
 }
 

--- a/pkg/metadata/meta.go
+++ b/pkg/metadata/meta.go
@@ -21,10 +21,10 @@ func ApplyMetaOptions(obj metav1.Object, opts ...Options) error {
 	return nil
 }
 
-// WithOwnerLabels sets the owner labels on the object based on source object.
-// Those labels can be used to find all related resources across the cluster
-// which are owned by the source object by leveraging label selectors.
-// This can be particularly useful for garbage collection when source object is namespace-scoped
+// WithOwnerLabels makes source object an owner of the target resource using labels.
+// Those labels can be used to find all related resources across the cluster which
+// are owned by the source object using label selectors which simplifies query to kube-apiserver.
+// This is particularly useful for garbage collection when source object is namespace-scoped
 // and related resources are created in a different namespace or are cluster-scoped.
 func WithOwnerLabels(source client.Object) Options {
 	ownerName := source.GetName()
@@ -33,6 +33,7 @@ func WithOwnerLabels(source client.Object) Options {
 	return WithLabels(
 		Labels.OwnerName, ownerName,
 		Labels.OwnerKind, ownerKind,
+		Labels.OwnerUID, string(source.GetUID()),
 	)
 }
 

--- a/pkg/resource/authorization/template/authconfig_userdefined.yaml
+++ b/pkg/resource/authorization/template/authconfig_userdefined.yaml
@@ -24,7 +24,7 @@ spec:
           group:
             value: ""
           resource:
-            value: services
+            value: services # TODO(mvp) switch to target protected resource
           namespace:
             value: {{ .Namespace }}
           subresource:

--- a/pkg/resource/routing/routing.go
+++ b/pkg/resource/routing/routing.go
@@ -27,8 +27,8 @@ func NewStaticTemplateLoader() spi.RoutingTemplateLoader {
 	return &staticTemplateLoader{}
 }
 
-func (s *staticTemplateLoader) Load(_ context.Context, routeType spi.RouteType, key types.NamespacedName, data spi.RoutingTemplateData) ([]unstructured.Unstructured, error) {
-	resources := []unstructured.Unstructured{}
+func (s *staticTemplateLoader) Load(_ context.Context, routeType spi.RouteType, key types.NamespacedName, data spi.RoutingTemplateData) ([]*unstructured.Unstructured, error) {
+	var resources []*unstructured.Unstructured
 
 	templateContent := publicRouteTemplate
 	if routeType == spi.ExternalRoute {
@@ -37,15 +37,15 @@ func (s *staticTemplateLoader) Load(_ context.Context, routeType spi.RouteType, 
 
 	resolvedTemplates, err := s.resolveTemplate(templateContent, data)
 	if err != nil {
-		return []unstructured.Unstructured{}, fmt.Errorf("could not resolve auth template: %w", err)
+		return nil, fmt.Errorf("could not resolve routing template: %w", err)
 	}
 
 	resolvedSplitTemplates := strings.Split(string(resolvedTemplates), "---")
 	for _, resolvedTemplate := range resolvedSplitTemplates {
-		resource := unstructured.Unstructured{}
+		resource := &unstructured.Unstructured{}
 
-		if errConvert := schema.ConvertToStructuredResource([]byte(resolvedTemplate), &resource); errConvert != nil {
-			return []unstructured.Unstructured{}, fmt.Errorf("could not load auth template: %w", err)
+		if errConvert := schema.ConvertToStructuredResource([]byte(resolvedTemplate), resource); errConvert != nil {
+			return nil, fmt.Errorf("could not load routing template: %w", err)
 		}
 
 		resources = append(resources, resource)

--- a/pkg/resource/routing/routing_test.go
+++ b/pkg/resource/routing/routing_test.go
@@ -16,15 +16,16 @@ var _ = Describe("Resource functions", test.Unit(), func() {
 	Context("Template Loader", func() {
 
 		data := spi.RoutingTemplateData{
+			PlatformRoutingConfiguration: spi.PlatformRoutingConfiguration{
+				GatewayNamespace:     "opendatahub",
+				IngressSelectorLabel: "istio",
+				IngressSelectorValue: "rhoai-gateway",
+				IngressService:       "rhoai-router-ingress",
+			},
 			PublicServiceName: "registry-office",
 			ServiceName:       "registry",
 			ServiceNamespace:  "office",
-			GatewayNamespace:  "opendatahub",
 			Domain:            "app-crc.testing",
-
-			IngressSelectorLabel: "istio",
-			IngressSelectorValue: "rhoai-gateway",
-			IngressService:       "rhoai-router-ingress",
 		}
 
 		It("should load public resources", func() {

--- a/pkg/resource/routing/template/routing_external.yaml
+++ b/pkg/resource/routing/template/routing_external.yaml
@@ -1,12 +1,13 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name:  # identity of the service being exposed
+  name: {{ .PublicServiceName }}-route # identity of the service being exposed
   namespace: {{ .GatewayNamespace }}
 spec:
   to:
     kind: Service
     name: {{ .IngressService }}
+  host: {{ .PublicServiceName }}.{{ .Domain }}
   port:
     targetPort: https
   tls:
@@ -29,4 +30,4 @@ spec:
     - destination:
         host: {{ .ServiceName }}.{{ .ServiceNamespace }}.svc.cluster.local   # srv k8s
         port:
-          number: 8080 # port number on mesh service
+          number: {{ .ServiceTargetPort }}

--- a/pkg/resource/routing/template/routing_public.yaml
+++ b/pkg/resource/routing/template/routing_public.yaml
@@ -12,6 +12,7 @@ spec:
   - name: https
     port: 443
     targetPort: 8443
+    protocol: TCP
 
 ---
 apiVersion: networking.istio.io/v1beta1
@@ -55,7 +56,7 @@ spec:
     - destination:
         host: {{ .ServiceName }}.{{ .ServiceNamespace }}.svc.cluster.local   # srv k8s
         port:
-          number: 8080 # port number on mesh service
+          number: {{ .ServiceTargetPort }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule

--- a/pkg/spi/types.go
+++ b/pkg/spi/types.go
@@ -97,17 +97,20 @@ func (a RoutingComponent) Load(configPath string) ([]RoutingComponent, error) {
 	return routes, nil
 }
 
+// TODO(mvp) revise the stuct name - is it only for templates?
 type RoutingTemplateData struct {
 	PublicServiceName string // [service-name]-[service-namespace]
-	ServiceName       string // service-name
-	ServiceNamespace  string // service-namespace
-	GatewayNamespace  string // gateway-namespace
-	Domain            string // app.crc.testing
+	ServiceName       string
+	ServiceNamespace  string
+	ServiceTargetPort string
+
+	GatewayNamespace string
+	Domain           string
 
 	// Infra
-	IngressSelectorLabel string // istio
-	IngressSelectorValue string // rhoai-gateway
-	IngressService       string // rhoai-router-ingress
+	IngressSelectorLabel string
+	IngressSelectorValue string
+	IngressService       string
 }
 
 // RoutingTemplateLoader provides a way to differentiate the Route template used based on
@@ -115,7 +118,7 @@ type RoutingTemplateData struct {
 //   - Namespace / Resource name
 //   - Loader source
 type RoutingTemplateLoader interface {
-	Load(ctx context.Context, routeType RouteType, key types.NamespacedName, data RoutingTemplateData) ([]unstructured.Unstructured, error)
+	Load(ctx context.Context, routeType RouteType, key types.NamespacedName, data RoutingTemplateData) ([]*unstructured.Unstructured, error)
 }
 
 type ResourceSchema struct {

--- a/pkg/spi/types.go
+++ b/pkg/spi/types.go
@@ -97,20 +97,24 @@ func (a RoutingComponent) Load(configPath string) ([]RoutingComponent, error) {
 	return routes, nil
 }
 
+type PlatformRoutingConfiguration struct {
+	IngressSelectorLabel,
+	IngressSelectorValue,
+	IngressService,
+	GatewayNamespace string
+}
+
 // TODO(mvp) revise the stuct name - is it only for templates?
 type RoutingTemplateData struct {
+	PlatformRoutingConfiguration
+
 	PublicServiceName string // [service-name]-[service-namespace]
 	ServiceName       string
 	ServiceNamespace  string
+
 	ServiceTargetPort string
 
-	GatewayNamespace string
-	Domain           string
-
-	// Infra
-	IngressSelectorLabel string
-	IngressSelectorValue string
-	IngressService       string
+	Domain string
 }
 
 // RoutingTemplateLoader provides a way to differentiate the Route template used based on

--- a/test/fixtures/default_openshift_ingress_config.yaml
+++ b/test/fixtures/default_openshift_ingress_config.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+spec:
+  domain: opendatahub.io

--- a/test/matchers/authconfig.go
+++ b/test/matchers/authconfig.go
@@ -9,36 +9,6 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-// HaveHosts is a custom matcher to verify hosts in AuthConfigs.
-func HaveHosts(expectedHosts ...string) types.GomegaMatcher {
-	return &authConfigHostsMatcher{expectedHosts: expectedHosts}
-}
-
-type authConfigHostsMatcher struct {
-	expectedHosts []string
-}
-
-func (matcher *authConfigHostsMatcher) Match(actual any) (bool, error) {
-	if actual == nil {
-		return false, nil
-	}
-
-	authConfig, ok := actual.(*authorinov1beta2.AuthConfig)
-	if !ok {
-		return false, fmt.Errorf("expected AuthConfig. Got:\n%s", format.Object(actual, 1))
-	}
-
-	return gomega.Equal(matcher.expectedHosts).Match(authConfig.Spec.Hosts)
-}
-
-func (matcher *authConfigHostsMatcher) FailureMessage(actual any) string {
-	return format.Message(actual, "to have hosts", matcher.expectedHosts)
-}
-
-func (matcher *authConfigHostsMatcher) NegatedFailureMessage(actual any) string {
-	return format.Message(actual, "not to have hosts", matcher.expectedHosts)
-}
-
 // HaveKubernetesTokenReview is a custom matcher to verify Kubernetes Token Review configuration in AuthConfigs.
 func HaveKubernetesTokenReview() types.GomegaMatcher {
 	return &kubernetesTokenReviewMatcher{}
@@ -51,8 +21,8 @@ func (matcher *kubernetesTokenReviewMatcher) Match(actual any) (bool, error) {
 		return false, nil
 	}
 
-	authConfig, ok := actual.(*authorinov1beta2.AuthConfig)
-	if !ok {
+	authConfig, err := deref[authorinov1beta2.AuthConfig](actual)
+	if err != nil {
 		return false, fmt.Errorf("expected AuthConfig. Got:\n%s", format.Object(actual, 1))
 	}
 
@@ -86,8 +56,8 @@ func (matcher *authConfigMethodMatcher) Match(actual any) (bool, error) {
 		return false, nil
 	}
 
-	authConfig, ok := actual.(*authorinov1beta2.AuthConfig)
-	if !ok {
+	authConfig, err := deref[authorinov1beta2.AuthConfig](actual)
+	if err != nil {
 		return false, fmt.Errorf("expected AuthConfig. Got:\n%s", format.Object(actual, 1))
 	}
 

--- a/test/matchers/host.go
+++ b/test/matchers/host.go
@@ -59,6 +59,12 @@ func extractHosts(actual any) ([]string, error) {
 		return vs.Spec.GetHosts(), nil
 	}
 
+	if dr, err := deref[v1beta1.DestinationRule](actual); err != nil {
+		derefErrors = errors.Join(derefErrors, err)
+	} else {
+		return []string{dr.Spec.GetHost()}, nil
+	}
+
 	if gw, err := deref[v1beta1.Gateway](actual); err != nil {
 		derefErrors = errors.Join(derefErrors, err)
 	} else {

--- a/test/matchers/host.go
+++ b/test/matchers/host.go
@@ -1,0 +1,75 @@
+package matchers
+
+import (
+	"errors"
+
+	"github.com/kuadrant/authorino/api/v1beta2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	openshiftroutev1 "github.com/openshift/api/route/v1"
+	"istio.io/client-go/pkg/apis/networking/v1beta1"
+)
+
+func HaveHost(name string) types.GomegaMatcher {
+	return &hostsMatcher{expectedHosts: []string{name}}
+}
+
+func HaveHosts(name ...string) types.GomegaMatcher {
+	return &hostsMatcher{expectedHosts: name}
+}
+
+type hostsMatcher struct {
+	expectedHosts []string
+}
+
+func (matcher *hostsMatcher) Match(actual any) (bool, error) {
+	if actual == nil {
+		return true, nil
+	}
+
+	actualHosts, errExtract := extractHosts(actual)
+	if errExtract != nil {
+		return false, errExtract
+	}
+
+	return gomega.ContainElements(matcher.expectedHosts).Match(actualHosts)
+}
+
+func (matcher *hostsMatcher) FailureMessage(actual any) string {
+	return format.Message(actual, "to have host prefix", matcher.expectedHosts)
+}
+
+func (matcher *hostsMatcher) NegatedFailureMessage(actual any) string {
+	return format.Message(actual, "to not have host prefix", matcher.expectedHosts)
+}
+
+func extractHosts(actual any) ([]string, error) {
+	var derefErrors error
+
+	if route, err := deref[openshiftroutev1.Route](actual); err != nil {
+		derefErrors = errors.Join(derefErrors, err)
+	} else {
+		return []string{route.Spec.Host}, nil
+	}
+
+	if vs, err := deref[v1beta1.VirtualService](actual); err != nil {
+		derefErrors = errors.Join(derefErrors, err)
+	} else {
+		return vs.Spec.GetHosts(), nil
+	}
+
+	if gw, err := deref[v1beta1.Gateway](actual); err != nil {
+		derefErrors = errors.Join(derefErrors, err)
+	} else {
+		return gw.Spec.GetServers()[0].GetHosts(), nil
+	}
+
+	if authConfig, err := deref[v1beta2.AuthConfig](actual); err != nil {
+		derefErrors = errors.Join(derefErrors, err)
+	} else {
+		return authConfig.Spec.Hosts, nil
+	}
+
+	return []string{""}, derefErrors
+}

--- a/test/matchers/host.go
+++ b/test/matchers/host.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	openshiftroutev1 "github.com/openshift/api/route/v1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -37,11 +36,11 @@ func (matcher *hostsMatcher) Match(actual any) (bool, error) {
 }
 
 func (matcher *hostsMatcher) FailureMessage(actual any) string {
-	return format.Message(actual, "to have host prefix", matcher.expectedHosts)
+	return gomega.ContainElements(matcher.expectedHosts).FailureMessage(actual)
 }
 
 func (matcher *hostsMatcher) NegatedFailureMessage(actual any) string {
-	return format.Message(actual, "to not have host prefix", matcher.expectedHosts)
+	return gomega.ContainElements(matcher.expectedHosts).FailureMessage(actual)
 }
 
 func extractHosts(actual any) ([]string, error) {

--- a/test/matchers/meta_object.go
+++ b/test/matchers/meta_object.go
@@ -1,12 +1,79 @@
 package matchers
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func HaveAnnotations(annotationsKV ...any) types.GomegaMatcher {
+	annotations, err := extractKeyValues(annotationsKV)
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("failed to extract annotations: %v", err))
+	}
+
+	return &annotationsMatcher{expectedAnnotations: annotations}
+}
+
+func extractKeyValues(keyValuePairs []any) (map[string]any, error) {
+	lenKV := len(keyValuePairs)
+	if lenKV%2 != 0 {
+		return nil, fmt.Errorf("passed elements should be in key/value pairs, but got %d elements", lenKV)
+	}
+
+	kvMap := make(map[string]any, lenKV%2)
+
+	for i := 0; i < lenKV; i += 2 { //nolint:varnamelen //reason: i is a common name for loop counters
+		key, ok := keyValuePairs[i].(string)
+		if !ok {
+			return nil, fmt.Errorf("passed key %T, expected string", keyValuePairs[i])
+		}
+
+		kvMap[key] = keyValuePairs[i+1]
+	}
+
+	return kvMap, nil
+}
+
+type annotationsMatcher struct {
+	expectedAnnotations map[string]any
+}
+
+func (r *annotationsMatcher) Match(actual any) (bool, error) {
+	metaObj, ok := actual.(metav1.Object)
+	if !ok {
+		return false, fmt.Errorf("object does not implement metav1.Object, got type %T", actual)
+	}
+
+	var matchErrs error
+
+	succeed := true
+	annotations := metaObj.GetAnnotations()
+
+	for key, value := range r.expectedAnnotations {
+		success, err := gomega.HaveKeyWithValue(key, value).Match(annotations)
+		if !success {
+			succeed = false
+		}
+
+		matchErrs = errors.Join(matchErrs, err)
+	}
+
+	return succeed, matchErrs
+}
+
+func (r *annotationsMatcher) FailureMessage(actual any) string {
+	return format.Message(actual, "to have annotations", r.expectedAnnotations)
+}
+
+func (r *annotationsMatcher) NegatedFailureMessage(actual any) string {
+	return format.Message(actual, "not to be attached to service named", r.expectedAnnotations)
+}
 
 func HaveOwnerReference(expectedOwner metav1.OwnerReference) types.GomegaMatcher {
 	return &ownerReferenceMatcher{expectedOwner: expectedOwner}

--- a/test/matchers/meta_object.go
+++ b/test/matchers/meta_object.go
@@ -1,79 +1,12 @@
 package matchers
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func HaveAnnotations(annotationsKV ...any) types.GomegaMatcher {
-	annotations, err := extractKeyValues(annotationsKV)
-	if err != nil {
-		ginkgo.Fail(fmt.Sprintf("failed to extract annotations: %v", err))
-	}
-
-	return &annotationsMatcher{expectedAnnotations: annotations}
-}
-
-func extractKeyValues(keyValuePairs []any) (map[string]any, error) {
-	lenKV := len(keyValuePairs)
-	if lenKV%2 != 0 {
-		return nil, fmt.Errorf("passed elements should be in key/value pairs, but got %d elements", lenKV)
-	}
-
-	kvMap := make(map[string]any, lenKV%2)
-
-	for i := 0; i < lenKV; i += 2 { //nolint:varnamelen //reason: i is a common name for loop counters
-		key, ok := keyValuePairs[i].(string)
-		if !ok {
-			return nil, fmt.Errorf("passed key %T, expected string", keyValuePairs[i])
-		}
-
-		kvMap[key] = keyValuePairs[i+1]
-	}
-
-	return kvMap, nil
-}
-
-type annotationsMatcher struct {
-	expectedAnnotations map[string]any
-}
-
-func (r *annotationsMatcher) Match(actual any) (bool, error) {
-	metaObj, ok := actual.(metav1.Object)
-	if !ok {
-		return false, fmt.Errorf("object does not implement metav1.Object, got type %T", actual)
-	}
-
-	var matchErrs error
-
-	succeed := true
-	annotations := metaObj.GetAnnotations()
-
-	for key, value := range r.expectedAnnotations {
-		success, err := gomega.HaveKeyWithValue(key, value).Match(annotations)
-		if !success {
-			succeed = false
-		}
-
-		matchErrs = errors.Join(matchErrs, err)
-	}
-
-	return succeed, matchErrs
-}
-
-func (r *annotationsMatcher) FailureMessage(actual any) string {
-	return format.Message(actual, "to have annotations", r.expectedAnnotations)
-}
-
-func (r *annotationsMatcher) NegatedFailureMessage(actual any) string {
-	return format.Message(actual, "not to be attached to service named", r.expectedAnnotations)
-}
 
 func HaveOwnerReference(expectedOwner metav1.OwnerReference) types.GomegaMatcher {
 	return &ownerReferenceMatcher{expectedOwner: expectedOwner}

--- a/test/matchers/route.go
+++ b/test/matchers/route.go
@@ -40,32 +40,3 @@ func (r *routeSvcMatcher) FailureMessage(actual any) string {
 func (r *routeSvcMatcher) NegatedFailureMessage(actual any) string {
 	return format.Message(actual, "not to be attached to service named", r.expectedSvcName)
 }
-
-func HaveHostPrefix(name string) types.GomegaMatcher {
-	return &routeHostPrefix{expectedHostPrefix: name}
-}
-
-type routeHostPrefix struct {
-	expectedHostPrefix string
-}
-
-func (matcher *routeHostPrefix) Match(actual any) (bool, error) {
-	if actual == nil {
-		return true, nil
-	}
-
-	route, errDeref := deref[openshiftroutev1.Route](actual)
-	if errDeref != nil {
-		return false, errDeref
-	}
-
-	return gomega.HavePrefix(matcher.expectedHostPrefix).Match(route.Spec.Host)
-}
-
-func (matcher *routeHostPrefix) FailureMessage(actual any) string {
-	return format.Message(actual, "to have host prefix", matcher.expectedHostPrefix)
-}
-
-func (matcher *routeHostPrefix) NegatedFailureMessage(actual any) string {
-	return format.Message(actual, "to not have host prefix", matcher.expectedHostPrefix)
-}

--- a/test/matchers/virtualservice.go
+++ b/test/matchers/virtualservice.go
@@ -1,0 +1,89 @@
+package matchers
+
+import (
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+	"istio.io/client-go/pkg/apis/networking/v1beta1"
+)
+
+// BeAttachedToGateways ensures that the VirtualService is attached to only specified gateways.
+func BeAttachedToGateways(targetGw ...string) types.GomegaMatcher {
+	return &vsGatewayMatcher{expectedGateways: targetGw}
+}
+
+type vsGatewayMatcher struct {
+	expectedGateways []string
+}
+
+func (v *vsGatewayMatcher) Match(actual any) (bool, error) {
+	if actual == nil {
+		return true, nil
+	}
+
+	vs, errDeref := deref[v1beta1.VirtualService](actual)
+	if errDeref != nil {
+		return false, errDeref
+	}
+
+	return gomega.And(gomega.ContainElements(v.expectedGateways), gomega.HaveLen(len(v.expectedGateways))).Match(vs.Spec.GetGateways())
+}
+
+func (v *vsGatewayMatcher) FailureMessage(actual any) string {
+	return format.Message(actual, "to be attached only to gateways", v.expectedGateways)
+}
+
+func (v *vsGatewayMatcher) NegatedFailureMessage(actual any) string {
+	return format.Message(actual, "not to be attached only to gateways", v.expectedGateways)
+}
+
+// RouteToHost ensures that the VirtualService is attached to only specified gateways.
+func RouteToHost(host string, port uint32) types.GomegaMatcher {
+	return &vsDestinationMatcher{
+		host: host,
+		port: port,
+	}
+}
+
+type vsDestinationMatcher struct {
+	host string
+	port uint32
+}
+
+func (v *vsDestinationMatcher) Match(actual any) (bool, error) {
+	if actual == nil {
+		return true, nil
+	}
+
+	vs, errDeref := deref[v1beta1.VirtualService](actual)
+	if errDeref != nil {
+		return false, errDeref
+	}
+
+	httpRouteMatcher := gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Route": gomega.ContainElement(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Destination": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Host": gomega.Equal(v.host),
+				"Port": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Number": gomega.Equal(v.port),
+				})),
+			})),
+		}))),
+	}))
+
+	return gomega.ContainElement(httpRouteMatcher).Match(vs.Spec.GetHttp())
+}
+
+func (v *vsDestinationMatcher) FailureMessage(actual any) string {
+	vs, errDeref := deref[v1beta1.VirtualService](actual)
+	if errDeref != nil {
+		return errDeref.Error()
+	}
+
+	return format.Message(vs.Spec.GetHttp(), "to be routing to ", v.host, ":", v.port)
+}
+
+func (v *vsDestinationMatcher) NegatedFailureMessage(actual any) string {
+	return format.Message(actual, "not to be routing to ", v.host, ":", v.port)
+}


### PR DESCRIPTION
## Summary

This update introduces new logic for creating and managing routing resources based on the `routing.opendatahub.io/export-mode` annotation present on the Component's CR. This annotation can have values `public`, `external`, or a combination of `public;external`, each resulting in different resources being created.

## Internal Routing for Non-Mesh Clients (public mode)

For non-mesh clients within the cluster, the following resources are required within the `gateway namespace`:

- **Service**: Represents each internal service for non-mesh clients, named `some-service-some-namespace.gateway-ns`
- **Secret**: Contains the serving certificate and key for the Service, generated by OpenShift via an annotation on the Service.
- **Gateway**: Configures the listener for each Service and references the Secret with the serving certificate and key. The Gateway is set to only listen for the FQDN of the Service (e.g., `some-service.some-namespace.svc` and `some-service.some-namespace.svc.cluster.local`).
- **VirtualService**: Applies to both the Gateway and the mesh, routing traffic to the appropriate backend service.

## External Routing (external mode)

For services exposed externally, the following resources are created within the `gateway namespace`:

- **Route**: Uses TLS re-encrypt and targets the shared Service defined above.
- **VirtualService**: Configures the Gateway to specify the target for the Route, directing traffic to the appropriate backend service. This VirtualService does not apply to the mesh.

## Metadata for Component Services

Services that should be exposed are expected to have certain **labels** set (e.g. by their controller).

To indicate that the service should be included in platform routing `routing.opendatahub.io/exported: "true"` should be added.

 To enable garbage collection (by this controller, not k8s itself) for platform routing resources, the following labels should be added:

- `platform.opendatahub.io/owner-name`: contains the owning Component's CR name.
- `platform.opendatahub.io/owner-kind`: contains the owning Component's CR kind.

These labels are needed because we cannot use  `OwnerReference` in all cases. Most components have their Custom Resources (CRs) namespace-scoped, as cross-namespace owner references are disallowed by design, we cannot use them as `OwnerReference`  for routing resources that we need to create in the `GATEWAY_NAMESPACE`. 

## Updating host information

When new routing resources are successfully created and new hosts defined, the routing controller places the following annotations directly on the Component CR instead of individual Services:

* `routing.opendatahub.io/public-addresses`
* `routing.opendatahub.io/external-addresses`

Both have values in a format of `;` separated list, e.g. 

`routing.opendatahub.io/addresses-public: some-service-some-namespace.gateway-ns;some-service-some-namespace.gateway-ns.svc;some-service-some-namespace.gateway-ns.svc.cluster.local`

This enables Platform Auth to read these addresses from the Component CR and update `AuthConfig`s host definitions accordingly.

> [!IMPORTANT]
> Implementation of `AuthConfig`s update pending.

## Current limitations

- Each component service to be exposed must have only one port defined.
- There is no support for VirtualService delegation yet. Meaning `VirtualService` with `routing.opendatahub.io/exported: "true"` label is not handled by the controller.
- Created resources are not automatically removed upon deletion of a watched CR (WIP follow-up issue: [RHOAIENG-10727](https://issues.redhat.com/browse/RHOAIENG-10727)).
- Resources required for a given export mode are not removed if the watched CR changes to a different export mode (follow-up issue: [RHOAIENG-11030](https://issues.redhat.com/browse/RHOAIENG-11030)).

## Additional Changes

### Reading Default Ingress Domain

This update ensures that externally exposed services have routes with hosts based on the public service name and domain configured for the OpenShift Ingress controller.

The external CRD for `ingresses.config.openshift.io` is now fetched as part of `make generate` using `$(call fetch-external-crds,github.com/openshift/api,config/v1)`. Notably, there is an inconsistency with the added CRD files, as they differ from those defined in the repository. Specifically, the Ingress CRD is mistakenly set to namespace-scoped instead of the expected cluster-scoped.


## Fixes

* https://issues.redhat.com/browse/RHOAIENG-10702
* https://issues.redhat.com/browse/RHOAIENG-10732
