### PR TITLE
chore: renames reconcilers to controllers

### DIFF
--- a/controllers/authorization/authorization_controller.go
+++ b/controllers/authorization/authorization_controller.go
@@ -23,9 +23,9 @@ import (
 
 const ctrlName = "authorization"
 
-func NewPlatformAuthorizationReconciler(cli client.Client, log logr.Logger,
-	component spi.AuthorizationComponent, config PlatformAuthorizationConfig) *PlatformAuthorizationReconciler {
-	return &PlatformAuthorizationReconciler{
+func NewPlatformAuthorizationController(cli client.Client, log logr.Logger,
+	component spi.AuthorizationComponent, config PlatformAuthorizationConfig) *PlatformAuthorizationController {
+	return &PlatformAuthorizationController{
 		Client: cli,
 		log: log.WithValues(
 			"controller", ctrlName,
@@ -48,8 +48,8 @@ type PlatformAuthorizationConfig struct {
 	ProviderName string
 }
 
-// PlatformAuthorizationReconciler holds the controller configuration.
-type PlatformAuthorizationReconciler struct {
+// PlatformAuthorizationController holds the controller configuration.
+type PlatformAuthorizationController struct {
 	client.Client
 	log            logr.Logger
 	config         PlatformAuthorizationConfig
@@ -64,7 +64,7 @@ type PlatformAuthorizationReconciler struct {
 // +kubebuilder:rbac:groups=security.istio.io,resources=peerauthentications,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile ensures that the namespace has all required resources needed to be part of the Service Mesh of Open Data Hub.
-func (r *PlatformAuthorizationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PlatformAuthorizationController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcilers := []platformctrl.SubReconcileFunc{r.reconcileAuthConfig, r.reconcileAuthPolicy, r.reconcilePeerAuthentication}
 
 	sourceRes := &unstructured.Unstructured{}
@@ -90,7 +90,7 @@ func (r *PlatformAuthorizationReconciler) Reconcile(ctx context.Context, req ctr
 	return ctrl.Result{}, errors.Join(errs...)
 }
 
-func (r *PlatformAuthorizationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PlatformAuthorizationController) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Client == nil {
 		// Ensures client is set - fall back to the one defined for the passed manager
 		r.Client = mgr.GetClient()

--- a/controllers/authorization/authorization_reconcile_authconfig.go
+++ b/controllers/authorization/authorization_reconcile_authconfig.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *PlatformAuthorizationReconciler) reconcileAuthConfig(ctx context.Context, target *unstructured.Unstructured) error {
+func (r *PlatformAuthorizationController) reconcileAuthConfig(ctx context.Context, target *unstructured.Unstructured) error {
 	hosts, err := r.extractHosts(target)
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func CompareAuthConfigs(m1, m2 *authorinov1beta2.AuthConfig) bool {
 		reflect.DeepEqual(m1.Spec, m2.Spec)
 }
 
-func (r *PlatformAuthorizationReconciler) createAuthConfigTemplate(ctx context.Context, target *unstructured.Unstructured) (authorinov1beta2.AuthConfig, error) {
+func (r *PlatformAuthorizationController) createAuthConfigTemplate(ctx context.Context, target *unstructured.Unstructured) (authorinov1beta2.AuthConfig, error) {
 	authType, err := r.typeDetector.Detect(ctx, target)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not detect authtype: %w", err)
@@ -130,7 +130,7 @@ func (r *PlatformAuthorizationReconciler) createAuthConfigTemplate(ctx context.C
 	return templ, nil
 }
 
-func (r *PlatformAuthorizationReconciler) extractHosts(target *unstructured.Unstructured) ([]string, error) {
+func (r *PlatformAuthorizationController) extractHosts(target *unstructured.Unstructured) ([]string, error) {
 	hosts, err := r.hostExtractor.Extract(target)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract host: %w", err)

--- a/controllers/authorization/authorization_reconcile_authpolicy.go
+++ b/controllers/authorization/authorization_reconcile_authpolicy.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *PlatformAuthorizationReconciler) reconcileAuthPolicy(ctx context.Context, target *unstructured.Unstructured) error {
+func (r *PlatformAuthorizationController) reconcileAuthPolicy(ctx context.Context, target *unstructured.Unstructured) error {
 	desired := createAuthzPolicy(r.authComponent.Ports, r.authComponent.WorkloadSelector, r.config.ProviderName, target)
 	found := &istiosecurityv1beta1.AuthorizationPolicy{}
 	justCreated := false

--- a/controllers/authorization/authorization_reconcile_peerauthentication.go
+++ b/controllers/authorization/authorization_reconcile_peerauthentication.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *PlatformAuthorizationReconciler) reconcilePeerAuthentication(ctx context.Context, target *unstructured.Unstructured) error {
+func (r *PlatformAuthorizationController) reconcilePeerAuthentication(ctx context.Context, target *unstructured.Unstructured) error {
 	desired := createPeerAuthentication(r.authComponent.WorkloadSelector, target)
 	found := &istiosecurityv1beta1.PeerAuthentication{}
 	justCreated := false

--- a/controllers/authorization/suite_test.go
+++ b/controllers/authorization/suite_test.go
@@ -30,7 +30,7 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 	}
 
 	envTest, cancelFunc = test.StartWithControllers(
-		authorization.NewPlatformAuthorizationReconciler(
+		authorization.NewPlatformAuthorizationController(
 			nil,
 			ctrl.Log.WithName("controllers").WithName("platform"),
 			spi.AuthorizationComponent{

--- a/controllers/routing/routing_controller.go
+++ b/controllers/routing/routing_controller.go
@@ -24,8 +24,8 @@ import (
 
 const ctrlName = "routing"
 
-func NewPlatformRoutingReconciler(cli client.Client, log logr.Logger, component spi.RoutingComponent, config spi.PlatformRoutingConfiguration) *PlatformRoutingReconciler {
-	return &PlatformRoutingReconciler{
+func NewPlatformRoutingController(cli client.Client, log logr.Logger, component spi.RoutingComponent, config spi.PlatformRoutingConfiguration) *PlatformRoutingController {
+	return &PlatformRoutingController{
 		Client: cli,
 		log: log.WithValues(
 			"controller", ctrlName,
@@ -37,8 +37,8 @@ func NewPlatformRoutingReconciler(cli client.Client, log logr.Logger, component 
 	}
 }
 
-// PlatformRoutingReconciler holds the controller configuration.
-type PlatformRoutingReconciler struct {
+// PlatformRoutingController holds the controller configuration.
+type PlatformRoutingController struct {
 	client.Client
 	log            logr.Logger
 	component      spi.RoutingComponent
@@ -52,7 +52,7 @@ type PlatformRoutingReconciler struct {
 // +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrule,verbs=*
 
 // Reconcile ensures that the namespace has all required resources needed to be part of the Service Mesh of Open Data Hub.
-func (r *PlatformRoutingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PlatformRoutingController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reconcilers := []platformctrl.SubReconcileFunc{r.reconcileResources}
 
 	sourceRes := &unstructured.Unstructured{}
@@ -93,7 +93,7 @@ func (r *PlatformRoutingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, errors.Join(errs...)
 }
 
-func (r *PlatformRoutingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PlatformRoutingController) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Client == nil {
 		// Ensures client is set - fall back to the one defined for the passed manager
 		r.Client = mgr.GetClient()

--- a/controllers/routing/routing_delete_resources.go
+++ b/controllers/routing/routing_delete_resources.go
@@ -13,7 +13,7 @@ import (
 )
 
 // HandleResourceDeletion handles the removal of dependent resources when the target resource is being deleted.
-func (r *PlatformRoutingReconciler) HandleResourceDeletion(ctx context.Context, sourceRes *unstructured.Unstructured) (ctrl.Result, error) {
+func (r *PlatformRoutingController) HandleResourceDeletion(ctx context.Context, sourceRes *unstructured.Unstructured) (ctrl.Result, error) {
 	exportModes, found := extractExportModes(sourceRes)
 	if !found {
 		r.log.Info("No export modes found, skipping deletion logic", "sourceRes", sourceRes)
@@ -32,7 +32,7 @@ func (r *PlatformRoutingReconciler) HandleResourceDeletion(ctx context.Context, 
 	return removeFinalizer(ctx, r.Client, sourceRes)
 }
 
-func (r *PlatformRoutingReconciler) deleteOwnedResources(ctx context.Context, target *unstructured.Unstructured, gvkList []schema.GroupVersionKind) error {
+func (r *PlatformRoutingController) deleteOwnedResources(ctx context.Context, target *unstructured.Unstructured, gvkList []schema.GroupVersionKind) error {
 	ownerName := target.GetName()
 	ownerKind := target.GetObjectKind().GroupVersionKind().Kind
 	ownerUID := string(target.GetUID())

--- a/controllers/routing/routing_reconcile_resources.go
+++ b/controllers/routing/routing_reconcile_resources.go
@@ -14,7 +14,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
-func (r *PlatformRoutingReconciler) reconcileResources(ctx context.Context, target *unstructured.Unstructured) error {
+func (r *PlatformRoutingController) reconcileResources(ctx context.Context, target *unstructured.Unstructured) error {
 	// TODO shouldn't we make it a predicate for ctrl watch instead?
 	_, exportModeFound := extractExportModes(target)
 	if !exportModeFound {
@@ -50,7 +50,7 @@ func (r *PlatformRoutingReconciler) reconcileResources(ctx context.Context, targ
 	return errors.Join(errSvcExport...)
 }
 
-func (r *PlatformRoutingReconciler) exportService(ctx context.Context, target *unstructured.Unstructured, exportedSvc *corev1.Service, domain string) error {
+func (r *PlatformRoutingController) exportService(ctx context.Context, target *unstructured.Unstructured, exportedSvc *corev1.Service, domain string) error {
 	exportModes, found := extractExportModes(target)
 	if !found {
 		return fmt.Errorf("could not extract export modes from target %s", target.GetName())

--- a/controllers/routing/suite_test.go
+++ b/controllers/routing/suite_test.go
@@ -37,7 +37,7 @@ var _ = SynchronizedBeforeSuite(func() {
 		return
 	}
 
-	routingCtrl := routing.NewPlatformRoutingReconciler(
+	routingCtrl := routing.NewPlatformRoutingController(
 		nil,
 		ctrl.Log.WithName("controllers").WithName("platform"),
 		spi.RoutingComponent{

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	for _, component := range authorizationComponents {
-		if err = authorization.NewPlatformAuthorizationReconciler(mgr.GetClient(), ctrlLog, component, authorizationConfig).
+		if err = authorization.NewPlatformAuthorizationController(mgr.GetClient(), ctrlLog, component, authorizationConfig).
 			SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "authorization", "component", component.ObjectReference.Kind)
 			os.Exit(1)
@@ -97,7 +97,7 @@ func main() {
 	}
 
 	for _, component := range routingComponents {
-		if err = routing.NewPlatformRoutingReconciler(
+		if err = routing.NewPlatformRoutingController(
 			mgr.GetClient(),
 			ctrlLog,
 			component,


### PR DESCRIPTION
This change renames the main types encapsulating reconciliation logic named `Platform{Authorization,Routing}` to have the suffix `Controller` rather than `Reconciler`.

Main rationale here is to be aligned with the terminology of `k8s/controller-runtime` framework.