### PR TITLE
chore(spi): relocates Authz platform config struct to pkg/spi

### DIFF
--- a/controllers/authorization/authorization_controller.go
+++ b/controllers/authorization/authorization_controller.go
@@ -24,7 +24,7 @@ import (
 const ctrlName = "authorization"
 
 func NewPlatformAuthorizationController(cli client.Client, log logr.Logger,
-	component spi.AuthorizationComponent, config PlatformAuthorizationConfig) *PlatformAuthorizationController {
+	component spi.AuthorizationComponent, config spi.PlatformAuthorizationConfig) *PlatformAuthorizationController {
 	return &PlatformAuthorizationController{
 		Client: cli,
 		log: log.WithValues(
@@ -39,20 +39,11 @@ func NewPlatformAuthorizationController(cli client.Client, log logr.Logger,
 	}
 }
 
-type PlatformAuthorizationConfig struct {
-	// Label in a format of key=value. It's used to target created AuthConfig by Authorino instance.
-	Label string
-	// Audiences is a list of audiences that will be used in the AuthConfig template when performing TokenReview.
-	Audiences []string
-	// ProviderName is the name of the registered external authorization provider in Service Mesh.
-	ProviderName string
-}
-
 // PlatformAuthorizationController holds the controller configuration.
 type PlatformAuthorizationController struct {
 	client.Client
 	log            logr.Logger
-	config         PlatformAuthorizationConfig
+	config         spi.PlatformAuthorizationConfig
 	authComponent  spi.AuthorizationComponent
 	typeDetector   spi.AuthTypeDetector
 	hostExtractor  spi.HostExtractor

--- a/controllers/authorization/suite_test.go
+++ b/controllers/authorization/suite_test.go
@@ -48,7 +48,7 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 					HostPaths:        []string{"spec.host"},
 				},
 			},
-			authorization.PlatformAuthorizationConfig{
+			spi.PlatformAuthorizationConfig{
 				Label:        config.GetAuthorinoLabel(),
 				Audiences:    config.GetAuthAudience(),
 				ProviderName: config.GetAuthProvider(),

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	authorizationConfig := authorization.PlatformAuthorizationConfig{
+	authorizationConfig := spi.PlatformAuthorizationConfig{
 		Label:        config.GetAuthorinoLabel(),
 		Audiences:    config.GetAuthAudience(),
 		ProviderName: config.GetAuthProvider(),

--- a/pkg/spi/types.go
+++ b/pkg/spi/types.go
@@ -26,6 +26,15 @@ type AuthorizationComponent struct {
 	platform.ProtectedResource
 }
 
+type PlatformAuthorizationConfig struct {
+	// Label in a format of key=value. It's used to target created AuthConfig by Authorino instance.
+	Label string
+	// Audiences is a list of audiences that will be used in the AuthConfig template when performing TokenReview.
+	Audiences []string
+	// ProviderName is the name of the registered external authorization provider in Service Mesh.
+	ProviderName string
+}
+
 // TODO: the config file will contain more then just AuthorizationComponents now.. adjust to read it multiple times pr Type or load it all at once..?
 // TODO: move the config load and save into a sub package and lazy share with operator.
 func (a AuthorizationComponent) Load(configPath string) ([]AuthorizationComponent, error) {
@@ -55,6 +64,8 @@ type AuthTypeDetector interface {
 	Detect(ctx context.Context, res *unstructured.Unstructured) (AuthType, error)
 }
 
+// Routing
+
 // AuthConfigTemplateLoader provides a way to differentiate the AuthConfig template used based on
 //   - AuthType
 //   - Namespace / Resource name
@@ -62,8 +73,6 @@ type AuthTypeDetector interface {
 type AuthConfigTemplateLoader interface {
 	Load(ctx context.Context, authType AuthType, key types.NamespacedName) (authorinov1beta2.AuthConfig, error)
 }
-
-// Routing
 
 type RouteType string
 
@@ -99,8 +108,8 @@ type PlatformRoutingConfiguration struct {
 	GatewayNamespace string
 }
 
-// TODO(mvp) revise the stuct name - is it only for templates?
-type RoutingTemplateData struct {
+// RoutingTemplateData is the data required to render a routing template.
+type RoutingTemplateData struct { // TODO(mvp): revise the stuct name - is it only for templates?
 	PlatformRoutingConfiguration
 
 	PublicServiceName string // [service-name]-[service-namespace]


### PR DESCRIPTION
Moves the authorization configuration struct to `pkg/spi/types.go` for consistency, as the routing configuration is already defined there.