### PR TITLE
feat(ctrl): introduces conditional reconcile

### DIFF
--- a/controllers/types.go
+++ b/controllers/types.go
@@ -7,6 +7,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+type Activable interface {
+	Activate()
+	Deactivate()
+}
+
 type SetupWithManagerFunc func(mgr ctrl.Manager) error
 
 type SubReconcileFunc func(ctx context.Context, target *unstructured.Unstructured) error

--- a/pkg/spi/types.go
+++ b/pkg/spi/types.go
@@ -29,6 +29,7 @@ type AuthorizationComponent struct {
 // TODO: the config file will contain more then just AuthorizationComponents now.. adjust to read it multiple times pr Type or load it all at once..?
 // TODO: move the config load and save into a sub package and lazy share with operator.
 func (a AuthorizationComponent) Load(configPath string) ([]AuthorizationComponent, error) {
+	// TODO(mvp): rework/simplify types
 	content, err := os.ReadFile(configPath + string(filepath.Separator) + "authorization")
 	if err != nil {
 		return []AuthorizationComponent{}, fmt.Errorf("could not read config file [%s]: %w", configPath, err)


### PR DESCRIPTION
We cannot remove watches from the running manager, so this change introduces new interface - `Activable` - which allows to alter the behaviour for a given controller/kind instance to skip reconcile when component is not enabled anymore.