### PR TITLE
feat: Support Platform Routing host annotations in Authorization

### DIFF
--- a/controllers/authorization/authorization_controller.go
+++ b/controllers/authorization/authorization_controller.go
@@ -38,7 +38,7 @@ func NewPlatformAuthorizationController(cli client.Client, log logr.Logger,
 		typeDetector:  authorization.NewAnnotationAuthTypeDetector(metadata.Annotations.AuthEnabled),
 		// TODO: Evaluate passing in the hostExtractor to avoid coupling the authorizaiton/routing packages
 		hostExtractor: authorization.UnifiedHostExtractor(
-			authorization.NewExpressionHostExtractor(component.HostPaths),
+			authorization.NewPathExpressionExtractor(component.HostPaths),
 			routing.NewAnnotationHostExtractor(";", metadata.Annotations.RoutingAddressesExternal, metadata.Annotations.RoutingAddressesPublic)),
 		templateLoader: authorization.NewConfigMapTemplateLoader(cli, authorization.NewStaticTemplateLoader(config.Audiences)),
 	}

--- a/controllers/authorization/authorization_reconcile_authconfig.go
+++ b/controllers/authorization/authorization_reconcile_authconfig.go
@@ -131,7 +131,7 @@ func (r *PlatformAuthorizationController) createAuthConfigTemplate(ctx context.C
 }
 
 func (r *PlatformAuthorizationController) extractHosts(target *unstructured.Unstructured) ([]string, error) {
-	hosts, err := r.hostExtractor.Extract(target)
+	hosts, err := r.hostExtractor(target)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract host: %w", err)
 	}

--- a/controllers/routing/routing_controller.go
+++ b/controllers/routing/routing_controller.go
@@ -51,7 +51,7 @@ type PlatformRoutingController struct {
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
-// +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrule,verbs=*
+// +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrules,verbs=*
 
 // Reconcile ensures that the namespace has all required resources needed to be part of the Service Mesh of Open Data Hub.
 func (r *PlatformRoutingController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/routing/routing_controller.go
+++ b/controllers/routing/routing_controller.go
@@ -51,7 +51,7 @@ type PlatformRoutingController struct {
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
-// +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrules,verbs=*
+// +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrule,verbs=*
 
 // Reconcile ensures that the namespace has all required resources needed to be part of the Service Mesh of Open Data Hub.
 func (r *PlatformRoutingController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -179,23 +179,23 @@ func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { /
 	return func(target *unstructured.Unstructured) ([]string, error) {
 		var errAll []error
 
-		extractedHosts := []string{}
+		combinedExtractedHosts := []string{}
 
 		for _, extractor := range extractors {
-			extractedDelegateHosts, err := extractor(target)
+			extractedHosts, err := extractor(target)
 			if err != nil {
 				errAll = append(errAll, err)
 
 				continue
 			}
 
-			extractedHosts, err = appendHosts(extractedHosts, extractedDelegateHosts...)
+			combinedExtractedHosts, err = appendHosts(combinedExtractedHosts, extractedHosts...)
 			if err != nil {
 				errAll = append(errAll, err)
 			}
 		}
 
-		return unique(extractedHosts), errors.Join(errAll...)
+		return unique(combinedExtractedHosts), errors.Join(errAll...)
 	}
 }
 

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -153,7 +153,7 @@ func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { /
 		return unique
 	}
 
-	isSupportedURL := func(host string) bool {
+	isURL := func(host string) bool {
 		return strings.HasPrefix(host, "http://") || strings.HasPrefix(host, "https://")
 	}
 
@@ -161,7 +161,7 @@ func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { /
 		var errAllParse []error
 
 		for _, foundHost := range foundHosts {
-			if isSupportedURL(foundHost) {
+			if isURL(foundHost) {
 				parsedURL, errParse := url.Parse(foundHost)
 				if errParse != nil {
 					errAllParse = append(errAllParse, fmt.Errorf("failed to parse URL %s: %w", foundHost, errParse))

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -133,7 +133,7 @@ func (k *annotationAuthTypeDetector) Detect(_ context.Context, res *unstructured
 	return spi.Anonymous, nil
 }
 
-func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { //nolint:gocognit //reason Inlined functions to avoid surface pollution
+func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { //nolint:gocognit //reason Inlined functions to avoid package pollution, "function scoped"
 	unique := func(in []string) []string {
 		set := map[string]bool{}
 

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -199,7 +199,7 @@ func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { /
 	}
 }
 
-func NewExpressionHostExtractor(paths []string) spi.HostExtractor {
+func NewPathExpressionExtractor(paths []string) spi.HostExtractor {
 	extractHosts := func(target *unstructured.Unstructured, splitPath []string) ([]string, error) {
 		// extracting as string
 		if foundHost, found, err := unstructured.NestedString(target.Object, splitPath...); err == nil && found {

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -135,22 +135,22 @@ func (k *annotationAuthTypeDetector) Detect(_ context.Context, res *unstructured
 
 func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { //nolint:gocognit //reason Inlined functions to avoid surface pollution
 	unique := func(in []string) []string {
-		store := map[string]bool{}
+		set := map[string]bool{}
 
-		for _, v := range in {
-			store[v] = true
+		for _, elem := range in {
+			set[elem] = true
 		}
 
-		keys := make([]string, len(store))
+		unique := make([]string, len(set))
 
 		i := 0
 
-		for v := range store {
-			keys[i] = v
+		for elem := range set {
+			unique[i] = elem
 			i++
 		}
 
-		return keys
+		return unique
 	}
 
 	isURI := func(host string) bool {

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -153,7 +153,7 @@ func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { /
 		return unique
 	}
 
-	isURI := func(host string) bool {
+	isSupportedURL := func(host string) bool {
 		return strings.HasPrefix(host, "http://") || strings.HasPrefix(host, "https://")
 	}
 
@@ -161,7 +161,7 @@ func UnifiedHostExtractor(extractors ...spi.HostExtractor) spi.HostExtractor { /
 		var errAllParse []error
 
 		for _, foundHost := range foundHosts {
-			if isURI(foundHost) {
+			if isSupportedURL(foundHost) {
 				parsedURL, errParse := url.Parse(foundHost)
 				if errParse != nil {
 					errAllParse = append(errAllParse, fmt.Errorf("failed to parse URL %s: %w", foundHost, errParse))

--- a/pkg/authorization/authconfig_test.go
+++ b/pkg/authorization/authconfig_test.go
@@ -60,7 +60,7 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 			hosts, err := authorization.UnifiedHostExtractor(extractor)(&target)
 			// then
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(hosts).To(ContainElements("test.com"))
+			Expect(hosts).To(HaveExactElements("test.com"))
 
 		})
 	})

--- a/pkg/authorization/authconfig_test.go
+++ b/pkg/authorization/authconfig_test.go
@@ -14,7 +14,7 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 
 		It("should extract host from unstructured via paths as string", func() {
 			// given
-			extractor := authorization.NewExpressionHostExtractor([]string{"status.url"})
+			extractor := authorization.NewPathExpressionExtractor([]string{"status.url"})
 			target := unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"status": map[string]interface{}{
@@ -33,7 +33,7 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 
 		It("should extract host from unstructured via paths as slice of strings", func() {
 			// given
-			extractor := authorization.NewExpressionHostExtractor([]string{"status.url"})
+			extractor := authorization.NewPathExpressionExtractor([]string{"status.url"})
 			target := unstructured.Unstructured{
 				Object: map[string]interface{}{},
 			}
@@ -50,7 +50,7 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 		It("should return unique list", func() {
 
 			// given
-			extractor := authorization.NewExpressionHostExtractor([]string{"status.url"})
+			extractor := authorization.NewPathExpressionExtractor([]string{"status.url"})
 			target := unstructured.Unstructured{
 				Object: map[string]interface{}{},
 			}

--- a/pkg/authorization/authconfig_test.go
+++ b/pkg/authorization/authconfig_test.go
@@ -54,7 +54,7 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 			target := unstructured.Unstructured{
 				Object: map[string]interface{}{},
 			}
-			unstructured.SetNestedStringSlice(target.Object, []string{"test.com", "http://test.com"}, "status", "url")
+			unstructured.SetNestedStringSlice(target.Object, []string{"test.com", "http://test.com", "https://test.com"}, "status", "url")
 
 			// when
 			hosts, err := authorization.UnifiedHostExtractor(extractor)(&target)

--- a/pkg/authorization/authconfig_test.go
+++ b/pkg/authorization/authconfig_test.go
@@ -24,11 +24,11 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 			}
 
 			// when
-			hosts, err := extractor.Extract(&target)
+			hosts, err := extractor(&target)
 
 			// then
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(hosts).To(HaveExactElements("test.com"))
+			Expect(hosts).To(HaveExactElements("http://test.com"))
 		})
 
 		It("should extract host from unstructured via paths as slice of strings", func() {
@@ -40,13 +40,29 @@ var _ = Describe("AuthConfig functions", test.Unit(), func() {
 			unstructured.SetNestedStringSlice(target.Object, []string{"test.com", "test2.com"}, "status", "url")
 
 			// when
-			hosts, err := extractor.Extract(&target)
+			hosts, err := extractor(&target)
 
 			// then
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(hosts).To(ContainElements("test.com", "test2.com"))
 		})
 
+		It("should return unique list", func() {
+
+			// given
+			extractor := authorization.NewExpressionHostExtractor([]string{"status.url"})
+			target := unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			}
+			unstructured.SetNestedStringSlice(target.Object, []string{"test.com", "http://test.com"}, "status", "url")
+
+			// when
+			hosts, err := authorization.UnifiedHostExtractor(extractor)(&target)
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(hosts).To(ContainElements("test.com"))
+
+		})
 	})
 
 })

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -69,3 +69,18 @@ func (s *staticTemplateLoader) resolveTemplate(tmpl []byte, data spi.RoutingTemp
 
 	return buf.Bytes(), nil
 }
+
+func NewAnnotationHostExtractor(separator string, annotations ...string) spi.HostExtractor {
+	return func(target *unstructured.Unstructured) ([]string, error) {
+		hosts := []string{}
+
+		for _, annotation := range annotations {
+			if val, found := target.GetAnnotations()[annotation]; found {
+				hs := strings.Split(val, separator)
+				hosts = append(hosts, hs...)
+			}
+		}
+
+		return hosts, nil
+	}
+}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opendatahub-io/odh-platform/pkg/routing"
 	"github.com/opendatahub-io/odh-platform/pkg/spi"
 	"github.com/opendatahub-io/odh-platform/test"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -50,6 +51,29 @@ var _ = Describe("Resource functions", test.Unit(), func() {
 			// then
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(res).To(HaveLen(2))
+		})
+
+	})
+
+	Context("Host extraction", func() {
+
+		It("should extract host from unstructured via paths as string", func() {
+			// given
+			extractor := routing.NewAnnotationHostExtractor(";", "A", "B")
+			target := unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			}
+			target.SetAnnotations(map[string]string{
+				"A": "a.com;a2.com",
+				"B": "b.com;b2.com",
+			})
+
+			// when
+			hosts, err := extractor(&target)
+
+			// then
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(hosts).To(HaveExactElements("a.com", "a2.com", "b.com", "b2.com"))
 		})
 
 	})

--- a/pkg/spi/types.go
+++ b/pkg/spi/types.go
@@ -46,9 +46,7 @@ func (a AuthorizationComponent) Load(configPath string) ([]AuthorizationComponen
 }
 
 // HostExtractor attempts to extract Hosts from the given resource.
-type HostExtractor interface {
-	Extract(res *unstructured.Unstructured) ([]string, error)
-}
+type HostExtractor func(res *unstructured.Unstructured) ([]string, error)
 
 // AuthTypeDetector attempts to determine the AuthType for the given resource
 // Possible implementations might check annotations or labels or possible related objects / config.


### PR DESCRIPTION
Platform Routing will write back Public and External addresses to the target CR and Platform Authorization needs to take these into account when setting up the AuthConfig as well as the hosts exposed in status by the target Controller.

https://issues.redhat.com/browse/RHOAIENG-11334