### PR TITLE
feat: add configurable serviceSelector instead of hardcoded labels

### DIFF
--- a/controllers/routingctrl/controller_test.go
+++ b/controllers/routingctrl/controller_test.go
@@ -92,7 +92,6 @@ var _ = Describe("Platform routing setup for the component", test.EnvTest(), fun
 			toRemove = append(toRemove, component)
 
 			// required labels for the exported service:
-			// 	routing.opendatahub.io/exported: "true"
 			// 	platform.opendatahub.io/owner-name: test-component
 			// 	platform.opendatahub.io/owner-kind: Component
 			addRoutingRequirementsToSvc(ctx, svc, component)

--- a/controllers/routingctrl/exported_svc_locator.go
+++ b/controllers/routingctrl/exported_svc_locator.go
@@ -5,21 +5,16 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-platform/pkg/metadata/labels"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getExportedServices(ctx context.Context, cli client.Client, target *unstructured.Unstructured) ([]corev1.Service, error) {
+func getExportedServices(ctx context.Context, cli client.Client, labels map[string]string, target *unstructured.Unstructured) ([]corev1.Service, error) {
 	listOpts := []client.ListOption{
 		client.InNamespace(target.GetNamespace()),
-		labels.MatchingLabels(
-			labels.RoutingExported("true"),
-			labels.OwnerName(target.GetName()),
-			labels.OwnerKind(target.GetObjectKind().GroupVersionKind().Kind),
-		),
+		client.MatchingLabels(labels),
 	}
 
 	var exportedSvcList *corev1.ServiceList

--- a/controllers/routingctrl/fixtures_test.go
+++ b/controllers/routingctrl/fixtures_test.go
@@ -31,20 +31,18 @@ func getClusterDomain(ctx context.Context, cli client.Client) string {
 	return domain
 }
 
-// addRoutingRequirementsToSvc adds routing-related metadata to the Service being exported.
-// It adds the "routing.opendatahub.io/exported" label to indicate that the service is exported,
-// and it also sets labels for the owner component's name and kind, using
-// "platform.opendatahub.io/owner-name" and "platform.opendatahub.io/owner-kind" respectively.
+// addRoutingRequirementsToSvc adds routing-related metadata to the Service being exported to match the
+// serviceSelector defined in the suite_test.
 func addRoutingRequirementsToSvc(ctx context.Context, exportedSvc *corev1.Service, owningComponent *unstructured.Unstructured) {
-	exportedLabel := labels.RoutingExported("true")
 	ownerName := labels.OwnerName(owningComponent.GetName())
 	ownerKind := labels.OwnerKind(owningComponent.GetObjectKind().GroupVersionKind().Kind)
 
 	_, errExportSvc := controllerutil.CreateOrUpdate(ctx, envTest.Client, exportedSvc, func() error {
-		metadata.ApplyMetaOptions(exportedSvc, exportedLabel, ownerName, ownerKind)
+		metadata.ApplyMetaOptions(exportedSvc, ownerName, ownerKind)
 
 		return nil
 	})
+
 	Expect(errExportSvc).ToNot(HaveOccurred())
 }
 

--- a/controllers/routingctrl/suite_test.go
+++ b/controllers/routingctrl/suite_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opendatahub-io/odh-platform/controllers/routingctrl"
+	"github.com/opendatahub-io/odh-platform/pkg/metadata/labels"
 	"github.com/opendatahub-io/odh-platform/pkg/platform"
 	"github.com/opendatahub-io/odh-platform/pkg/spi"
 	"github.com/opendatahub-io/odh-platform/test"
@@ -37,6 +38,9 @@ var _ = SynchronizedBeforeSuite(func() {
 		return
 	}
 
+	ownerName := labels.OwnerName("{{.metadata.name}}")
+	ownerKind := labels.OwnerKind("{{.kind}}")
+
 	routingCtrl := routingctrl.New(
 		nil,
 		ctrl.Log.WithName("controllers").WithName("platform"),
@@ -49,6 +53,7 @@ var _ = SynchronizedBeforeSuite(func() {
 						Kind:    "Component",
 					},
 				},
+				ServiceSelector: labels.MatchingLabels(ownerName, ownerKind),
 			},
 		},
 		routingConfiguration,

--- a/pkg/config/selectors.go
+++ b/pkg/config/selectors.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ResolveSelectors uses golang template engine to resolve the expressions in the `selectorExpressions` map using
+// `source` as a data input. Both the keys and values are resolved against the source data.
+//
+// Note: expressions are resolved against the source using lowercase keys
+//
+// Example source:
+//
+//	  kind: Service
+//	  metadata:
+//		   name: MyService
+//
+// Example selectorExpressions:
+//
+//	 map[string]{string} {
+//		  "routing.opendatahub.io/{{.kind}}": "{{.metadata.name}}", // > "routing.opendatahub.io/Service": "MyService"
+//	 }
+func ResolveSelectors(selectorExpressions map[string]string, source *unstructured.Unstructured) (map[string]string, error) {
+	resolved := make(map[string]string, len(selectorExpressions))
+	mainTemplate := template.New("unused_name").Option("missingkey=error")
+
+	for key, val := range selectorExpressions {
+		var err error
+
+		resolvedKey := key
+		if strings.Contains(key, "{{") {
+			resolvedKey, err = resolve(mainTemplate, key, source)
+			if err != nil {
+				return nil, fmt.Errorf("could not resolve key %s: %w", key, err)
+			}
+		}
+
+		resolvedVal := val
+		if strings.Contains(val, "{{") {
+			resolvedVal, err = resolve(mainTemplate, val, source)
+			if err != nil {
+				return nil, fmt.Errorf("could not resolve value %s: %w", val, err)
+			}
+		}
+
+		resolved[resolvedKey] = resolvedVal
+	}
+
+	return resolved, nil
+}
+
+func resolve(templ *template.Template, textTemplate string, source *unstructured.Unstructured) (string, error) {
+	tmpl, err := templ.Parse(textTemplate)
+	if err != nil {
+		return "", fmt.Errorf("could not parse template: %w", err)
+	}
+
+	var buff bytes.Buffer
+
+	if err := tmpl.Execute(&buff, source.Object); err != nil {
+		return "", fmt.Errorf("could not execute template: %w", err)
+	}
+
+	return buff.String(), nil
+}

--- a/pkg/config/selectors_test.go
+++ b/pkg/config/selectors_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Templated selectors", test.Unit(), func() {
 
 			_, err := config.ResolveSelectors(labels, &target)
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not execute template"))
+			Expect(err.Error()).To(ContainSubstring("could not resolve value"))
 		})
 	})
 

--- a/pkg/config/selectors_test.go
+++ b/pkg/config/selectors_test.go
@@ -1,0 +1,49 @@
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opendatahub-io/odh-platform/pkg/config"
+	"github.com/opendatahub-io/odh-platform/test"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Templated selectors", test.Unit(), func() {
+
+	Context("simple expressions", func() {
+
+		It("should resolve simple expressions for both key and value", func() {
+			labels := map[string]string{
+				"A.{{.kind}}": "{{.metadata.name}}",
+				"B":           "{{.kind}}",
+			}
+
+			target := unstructured.Unstructured{
+				Object: map[string]any{},
+			}
+			target.SetName("X")
+			target.SetKind("Y")
+
+			renderedLabels, err := config.ResolveSelectors(labels, &target)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(renderedLabels["A.Y"]).To(Equal("X"))
+			Expect(renderedLabels["B"]).To(Equal("Y"))
+		})
+
+		It("should fail on missing expression", func() {
+			labels := map[string]string{
+				"A": "{{.metadata.name}}",
+			}
+
+			target := unstructured.Unstructured{
+				Object: map[string]any{},
+			}
+			target.SetKind("Y")
+
+			_, err := config.ResolveSelectors(labels, &target)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+})

--- a/pkg/metadata/labels/types.go
+++ b/pkg/metadata/labels/types.go
@@ -131,24 +131,6 @@ func (o OwnerUID) Value() string {
 	return string(o)
 }
 
-// RoutingExported is a Label to mark resources that are exported by the routing capability.
-// It is intended to be set by enrolled component to mark resources that should be used to
-// configure routing capability by the Platform. This can be a Kubernetes Service or Istio
-// VirtualService from which settings like hosts and ports are extracted.
-type RoutingExported string
-
-func (r RoutingExported) ApplyToMeta(obj metav1.Object) {
-	addLabel(r, obj)
-}
-
-func (r RoutingExported) Key() string {
-	return "routing.opendatahub.io/exported"
-}
-
-func (r RoutingExported) Value() string {
-	return string(r)
-}
-
 func addLabel(label Label, obj metav1.Object) {
 	existingLabels := obj.GetLabels()
 	if existingLabels == nil {

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -16,6 +16,12 @@ type ObjectReference struct {
 type RoutingTarget struct {
 	// ObjectReference provides reference details to the associated object.
 	ObjectReference `json:"ref,omitempty"`
+	// ServiceSelector is a LabelSelector definition to locate the Service(s) to expose to Routing for the given ObjectReference.
+	// All provided label selectors must be present on the Service to find a match.
+	//
+	// go expressions are handled in the selector key and value to set dynamic values from the current ObjectReference;
+	// e.g. "routing.opendatahub.io/{{.kind}}": "{{.metadata.name}}", // > "routing.opendatahub.io/Service": "MyService"
+	ServiceSelector map[string]string `json:"serviceSelector,omitempty"`
 }
 
 // ProtectedResource  holds references and configuration details necessary for


### PR DESCRIPTION
Allow a component to configure the label selectors used to select the services
that should be exposable. This allows Platform Routing to operator
on an unchanged target.

ServiceSelectors also allow templating of the key and value in the configuration
to extract data from the Target CR resource.

Example:

"routing.opendatahub.io/{{.kind}}": "{{.metadata.name}}", // > "routing.opendatahub.io/Service": "MyService"

> [!CAUTION]
> the target CR is represented as a map[string]any with lowercase
> so in contrast to the Object representation {{ .Name }} it's required to
> write the full object path as {{ .metadata.name }}

- [x] More complete test case
- [x] Live test (can't be done until the task below is complete)
- [x] Update odh-operator MR config (can't be done until this is in main)
- [x] Should support TemplateLabels for WorkloadSelector as well (separate pr)