### PR TITLE
refactor: moves unstruct funcs to its own pkg

### DIFF
--- a/controllers/routing/routing_reconcile_resources.go
+++ b/controllers/routing/routing_reconcile_resources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendatahub-io/odh-platform/pkg/metadata/annotations"
 	"github.com/opendatahub-io/odh-platform/pkg/metadata/labels"
 	"github.com/opendatahub-io/odh-platform/pkg/spi"
+	"github.com/opendatahub-io/odh-platform/pkg/unstruct"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,7 +79,7 @@ func (r *PlatformRoutingController) exportService(ctx context.Context, target *u
 			return fmt.Errorf("could not load templates for type %s: %w", exportMode, err)
 		}
 
-		if errApply := cluster.Apply(ctx, r.Client, resources, ownershipLabels...); errApply != nil {
+		if errApply := unstruct.Apply(ctx, r.Client, resources, ownershipLabels...); errApply != nil {
 			return fmt.Errorf("could not apply routing resources for type %s: %w", exportMode, errApply)
 		}
 	}

--- a/pkg/unstruct/funcs.go
+++ b/pkg/unstruct/funcs.go
@@ -1,4 +1,4 @@
-package cluster
+package unstruct
 
 import (
 	"context"


### PR DESCRIPTION
Operations on unstructured k8s objects should be kept in its own pkg for better code organization. We use this struct to dynamically handle watched CRs as we do not want to import types of every component for which we provide platform capabilites. Often such types might not exist as as a dedicated client-go library with generated stubs.

This change creates new `pkg/unstruct` where we should start organizing helper functions.