### PR TITLE
fix(rbac): defines missing k8s svc roles

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,12 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
   - authorino.kuadrant.io
   resources:
   - authconfigs

--- a/controllers/routingctrl/controller.go
+++ b/controllers/routingctrl/controller.go
@@ -52,6 +52,7 @@ type Controller struct {
 // +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
 // +kubebuilder:rbac:groups="networking.istio.io",resources=destinationrules,verbs=*
+// +kubebuilder:rbac:groups="",resources=services,verbs=*
 
 // Reconcile ensures that the component has all required resources needed to use routing capability of the platform.
 func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
As we are creating services to facilitate non-mesh, cluster-local clients wanting to call mesh services we need roles for that. With the current integration as embedded ctrl in ODH Operator we are inheriting those already created for existing manager, but we need to make sure that we can also run in a standalone mode.

This change adds kubebuilder directive to create required roles for the k8s service resources.