### PR TITLE
feat: add expression support to workloadSelector (#57)

### DIFF
--- a/controllers/authzctrl/controller_test.go
+++ b/controllers/authzctrl/controller_test.go
@@ -138,6 +138,8 @@ var _ = Describe("Checking Authorization Resource Creation", test.EnvTest(), fun
 			}
 
 			Expect(createdAuthPolicy.Spec.GetAction()).To(Equal(v1beta1.AuthorizationPolicy_CUSTOM))
+			// WorkloadSelector expresssion defined in suite_test
+			Expect(createdAuthPolicy.Spec.GetSelector().GetMatchLabels()).To(HaveKeyWithValue("component", resourceName))
 
 			return nil
 		}, test.DefaultTimeout, test.DefaultPolling).Should(Succeed())

--- a/controllers/authzctrl/reconcile_authpolicy.go
+++ b/controllers/authzctrl/reconcile_authpolicy.go
@@ -29,11 +29,10 @@ func (r *Controller) reconcileAuthPolicy(ctx context.Context, target *unstructur
 	found := &istiosecurityv1beta1.AuthorizationPolicy{}
 	justCreated := false
 
-	err = r.Get(ctx, types.NamespacedName{
+	typeName := types.NamespacedName{
 		Name:      desired.Name,
-		Namespace: desired.Namespace,
-	}, found)
-	if err != nil {
+		Namespace: desired.Namespace}
+	if errGet := r.Get(ctx, typeName, found); errGet != nil {
 		if k8serr.IsNotFound(err) {
 			errCreate := r.Create(ctx, desired)
 			if client.IgnoreAlreadyExists(errCreate) != nil {
@@ -42,7 +41,7 @@ func (r *Controller) reconcileAuthPolicy(ctx context.Context, target *unstructur
 
 			justCreated = true
 		} else {
-			return fmt.Errorf("unable to fetch AuthorizationPolicy: %w", err)
+			return fmt.Errorf("unable to fetch AuthorizationPolicy: %w", errGet)
 		}
 	}
 

--- a/controllers/authzctrl/suite_test.go
+++ b/controllers/authzctrl/suite_test.go
@@ -43,9 +43,11 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 						},
 						Resources: "components",
 					},
-					WorkloadSelector: map[string]string{},
-					Ports:            []string{},
-					HostPaths:        []string{"spec.host"},
+					WorkloadSelector: map[string]string{
+						"component": "{{.metadata.name}}",
+					},
+					Ports:     []string{},
+					HostPaths: []string{"spec.host"},
 				},
 			},
 			authzctrl.PlatformAuthorizationConfig{

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -31,6 +31,10 @@ type ProtectedResource struct {
 	ObjectReference `json:"ref,omitempty"`
 	// WorkloadSelector defines labels used to identify and select the specific workload
 	// to which the authorization policy should be applied.
+	// All provided label selectors must be present on the Service to find a match.
+	//
+	// go expressions are handled in the selector key and value to set dynamic values from the current ObjectReference;
+	// e.g. "routing.opendatahub.io/{{.kind}}": "{{.metadata.name}}", // > "routing.opendatahub.io/Service": "MyService"
 	WorkloadSelector map[string]string `json:"workloadSelector,omitempty"`
 	// HostPaths defines paths in custom resource where hosts for this component are defined.
 	HostPaths []string `json:"hostPaths,omitempty"` // TODO(mvp): should we switch to annotations like in routing?


### PR DESCRIPTION
WorkloadSelectors allow templating of the key and value in the configuration to extract data from the Target CR resource.

Example:

 "auth.opendatahub.io/{{.kind}}": "{{.metadata.name}}", // >
 "auth.opendatahub.io/Service": "MyService"

> [!CAUTION]
> the target CR is represented as a map[string]any with lowercase
> so in contrast to the Object representation {{ .Name }} it's required
> to write the full object path as {{ .metadata.name }}