### PR TITLE
chore: simplifies resource loading

### DIFF
--- a/pkg/metadata/labels/funcs.go
+++ b/pkg/metadata/labels/funcs.go
@@ -38,7 +38,12 @@ func StandardLabelsFrom(source metav1.Object) []metadata.Option {
 // AppendStandardLabelsFrom appends standard labels found in source object but only
 // when they are not already present in the target object.
 func AppendStandardLabelsFrom(source metav1.Object) *LabelAppender {
-	return &LabelAppender{labels: standardLabelsFrom(source)}
+	return AppendLabels(standardLabelsFrom(source)...)
+}
+
+// AppendLabels appends provided labels to the target object but only when they are not already present.
+func AppendLabels(labels ...Label) *LabelAppender {
+	return &LabelAppender{labels: labels}
 }
 
 // MatchingLabels returns a client.MatchingLabels selector for the provided labels.

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -2,7 +2,6 @@ package routing
 
 import (
 	"bytes"
-	"context"
 	_ "embed" // needed for go:embed directive
 	"fmt"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	"github.com/opendatahub-io/odh-platform/pkg/schema"
 	"github.com/opendatahub-io/odh-platform/pkg/spi"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 //go:embed template/routing_public.yaml
@@ -27,7 +25,7 @@ func NewStaticTemplateLoader() spi.RoutingTemplateLoader {
 	return &staticTemplateLoader{}
 }
 
-func (s *staticTemplateLoader) Load(_ context.Context, routeType spi.RouteType, key types.NamespacedName, data spi.RoutingTemplateData) ([]*unstructured.Unstructured, error) {
+func (s *staticTemplateLoader) Load(data *spi.RoutingData, routeType spi.RouteType) ([]*unstructured.Unstructured, error) {
 	var resources []*unstructured.Unstructured
 
 	var templateContent []byte
@@ -60,7 +58,7 @@ func (s *staticTemplateLoader) Load(_ context.Context, routeType spi.RouteType, 
 	return resources, nil
 }
 
-func (s *staticTemplateLoader) resolveTemplate(tmpl []byte, data spi.RoutingTemplateData) ([]byte, error) {
+func (s *staticTemplateLoader) resolveTemplate(tmpl []byte, data *spi.RoutingData) ([]byte, error) {
 	engine, err := template.New("routing").Parse(string(tmpl))
 	if err != nil {
 		return []byte{}, fmt.Errorf("could not create template engine: %w", err)


### PR DESCRIPTION
Route resources loader has many unused parameters being part of the interface definition.

This change streamlines the abstraction to only rely on a route data structure and type based on which particular resources are loaded.

Data structure holding routing information has been renamed to RoutingData and new constructor func has been introduced to encapsulate logic of creating service-related fields.