### PR TITLE
chore: moves authz config struct

### DIFF
--- a/controllers/authzctrl/controller.go
+++ b/controllers/authzctrl/controller.go
@@ -26,7 +26,7 @@ import (
 const name = "authorization"
 
 func New(cli client.Client, log logr.Logger,
-	protectedResource platform.ProtectedResource, config PlatformAuthorizationConfig) *Controller {
+	protectedResource platform.ProtectedResource, config authorization.ProviderConfig) *Controller {
 	return &Controller{
 		active: true,
 		Client: cli,
@@ -45,21 +45,12 @@ func New(cli client.Client, log logr.Logger,
 	}
 }
 
-type PlatformAuthorizationConfig struct {
-	// Label in a format of key=value. It's used to target created AuthConfig by Authorino instance.
-	Label string
-	// Audiences is a list of audiences that will be used in the AuthConfig template when performing TokenReview.
-	Audiences []string
-	// ProviderName is the name of the registered external authorization provider in Service Mesh.
-	ProviderName string
-}
-
 // Controller holds the authorization controller configuration.
 type Controller struct {
 	client.Client
 	active            bool
 	log               logr.Logger
-	config            PlatformAuthorizationConfig
+	config            authorization.ProviderConfig
 	protectedResource platform.ProtectedResource
 	typeDetector      authorization.AuthTypeDetector
 	hostExtractor     spi.HostExtractor

--- a/controllers/authzctrl/suite_test.go
+++ b/controllers/authzctrl/suite_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/opendatahub-io/odh-platform/controllers/authzctrl"
+	"github.com/opendatahub-io/odh-platform/pkg/authorization"
 	"github.com/opendatahub-io/odh-platform/pkg/config"
 	"github.com/opendatahub-io/odh-platform/pkg/platform"
 	"github.com/opendatahub-io/odh-platform/test"
@@ -47,7 +48,7 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) {
 				Ports:     []string{},
 				HostPaths: []string{"spec.host"},
 			},
-			authzctrl.PlatformAuthorizationConfig{
+			authorization.ProviderConfig{
 				Label:        config.GetAuthorinoLabel(),
 				Audiences:    config.GetAuthAudience(),
 				ProviderName: config.GetAuthProvider(),

--- a/controllers/routingctrl/controller.go
+++ b/controllers/routingctrl/controller.go
@@ -26,7 +26,7 @@ const (
 	finalizerName = "routing.opendatahub.io/finalizer"
 )
 
-func New(cli client.Client, log logr.Logger, target platform.RoutingTarget, config routing.PlatformRoutingConfiguration) *Controller {
+func New(cli client.Client, log logr.Logger, target platform.RoutingTarget, config routing.IngressConfig) *Controller {
 	return &Controller{
 		active: true,
 		Client: cli,
@@ -47,7 +47,7 @@ type Controller struct {
 	log            logr.Logger
 	component      platform.RoutingTarget
 	templateLoader routing.TemplateLoader
-	config         routing.PlatformRoutingConfiguration
+	config         routing.IngressConfig
 }
 
 // +kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=*

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -68,7 +68,7 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 func (r *Controller) exportService(ctx context.Context, target *unstructured.Unstructured, exportedSvc *corev1.Service, domain string) error {
 	exportModes := r.extractExportModes(target)
 
-	templateData := routing.NewExposedServiceConfig(r.config, exportedSvc, domain)
+	templateData := routing.NewExposedServiceConfig(exportedSvc, r.config, domain)
 
 	// To establish ownership for watched component
 	ownershipLabels := append(labels.AsOwner(target), labels.AppManagedBy("odh-routing-controller"))

--- a/controllers/routingctrl/suite_test.go
+++ b/controllers/routingctrl/suite_test.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	envTest              *k8senvtest.Client
-	routingConfiguration = routing.PlatformRoutingConfiguration{
+	routingConfiguration = routing.IngressConfig{
 		IngressService:       "odh-router",
 		GatewayNamespace:     "odh-gateway",
 		IngressSelectorLabel: "istio",

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opendatahub-io/odh-platform/controllers/authzctrl"
 	"github.com/opendatahub-io/odh-platform/controllers/routingctrl"
+	"github.com/opendatahub-io/odh-platform/pkg/authorization"
 	"github.com/opendatahub-io/odh-platform/pkg/config"
 	"github.com/opendatahub-io/odh-platform/pkg/platform"
 	"github.com/opendatahub-io/odh-platform/pkg/routing"
@@ -73,7 +74,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	authorizationConfig := authzctrl.PlatformAuthorizationConfig{
+	authorizationConfig := authorization.ProviderConfig{
 		Label:        config.GetAuthorinoLabel(),
 		Audiences:    config.GetAuthAudience(),
 		ProviderName: config.GetAuthProvider(),
@@ -95,7 +96,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	routingConfig := routing.PlatformRoutingConfiguration{
+	routingConfig := routing.IngressConfig{
 		IngressSelectorLabel: config.GetIngressSelectorKey(),
 		IngressSelectorValue: config.GetIngressSelectorValue(),
 		IngressService:       config.GetGatewayService(),

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -8,6 +8,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// ProviderConfig holds the configuration for the authorization component as defined by the platform.
+type ProviderConfig struct {
+	// Label in a format of key=value. It's used to target created AuthConfig by Authorino instance.
+	Label string
+	// Audiences is a list of audiences used in the AuthConfig template when performing TokenReview.
+	Audiences []string
+	// ProviderName is the name of the registered external authorization provider in Service Mesh.
+	ProviderName string
+}
+
+// AuthType represents the type of authentication to be used for a given resource.
 type AuthType string
 
 const (

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -16,31 +16,28 @@ var _ = Describe("Resource functions", test.Unit(), func() {
 
 	Context("Template Loader", func() {
 
-		config := routing.PlatformRoutingConfiguration{
+		config := routing.IngressConfig{
 			GatewayNamespace:     "opendatahub",
 			IngressSelectorLabel: "istio",
 			IngressSelectorValue: "rhoai-gateway",
 			IngressService:       "rhoai-router-ingress",
 		}
 
-		data := routing.NewExposedServiceConfig(config,
-			&corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "registry",
-					Namespace: "office",
-				},
-				Spec: corev1.ServiceSpec{
-					Ports: []corev1.ServicePort{
-						{
-							Name:        "http-api",
-							Port:        80,
-							AppProtocol: ptr.To("http"),
-						},
+		data := routing.NewExposedServiceConfig(&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "registry",
+				Namespace: "office",
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:        "http-api",
+						Port:        80,
+						AppProtocol: ptr.To("http"),
 					},
 				},
 			},
-			"app-crc.testing",
-		)
+		}, config, "app-crc.testing")
 
 		It("should load public resources", func() {
 			// given

--- a/pkg/routing/types.go
+++ b/pkg/routing/types.go
@@ -40,15 +40,19 @@ func UnusedRouteTypes(exportModes []RouteType) []RouteType {
 	return unused
 }
 
-type PlatformRoutingConfiguration struct {
+// IngressConfig holds the configuration for the ingress resources (Istio Ingress Gateway services).
+// These values determine how and where additional resources required for platform routing will be created.
+type IngressConfig struct {
 	IngressSelectorLabel,
 	IngressSelectorValue,
 	IngressService,
 	GatewayNamespace string
 }
 
+// ExposedServiceConfig holds the configuration for a service that is used to serve as a cluster-local service facade
+// allowing non-mesh clients to access mesh services.
 type ExposedServiceConfig struct {
-	PlatformRoutingConfiguration
+	IngressConfig
 	PublicServiceName,
 	ServiceName,
 	ServiceNamespace,
@@ -56,14 +60,14 @@ type ExposedServiceConfig struct {
 	Domain string
 }
 
-func NewExposedServiceConfig(config PlatformRoutingConfiguration, svc *corev1.Service, domain string) *ExposedServiceConfig {
+func NewExposedServiceConfig(svc *corev1.Service, config IngressConfig, domain string) *ExposedServiceConfig {
 	return &ExposedServiceConfig{
-		PlatformRoutingConfiguration: config,
-		PublicServiceName:            svc.GetName() + "-" + svc.GetNamespace(),
-		ServiceName:                  svc.GetName(),
-		ServiceNamespace:             svc.GetNamespace(),
-		ServiceTargetPort:            svc.Spec.Ports[0].TargetPort.String(),
-		Domain:                       domain,
+		IngressConfig:     config,
+		PublicServiceName: svc.GetName() + "-" + svc.GetNamespace(),
+		ServiceName:       svc.GetName(),
+		ServiceNamespace:  svc.GetNamespace(),
+		ServiceTargetPort: svc.Spec.Ports[0].TargetPort.String(),
+		Domain:            domain,
 	}
 }
 


### PR DESCRIPTION
Follow up to #70 where I missed that PlatformAuthzConfig struct was in ctrl pkg. This PR moves it to authz pkg, so it's placed similarly to its routing counter-part.