### PR TITLE
feat(controller): pass configuration in as part of activation

### DIFF
--- a/controllers/authzctrl/controller.go
+++ b/controllers/authzctrl/controller.go
@@ -41,7 +41,7 @@ func New(cli client.Client, log logr.Logger,
 		hostExtractor: spi.UnifiedHostExtractor(
 			spi.NewPathExpressionExtractor(protectedResource.HostPaths),
 			spi.NewAnnotationHostExtractor(";", metadata.Keys(annotations.RoutingAddressesExternal(""), annotations.RoutingAddressesPublic(""))...)),
-		templateLoader: authorization.NewConfigMapTemplateLoader(cli, authorization.NewStaticTemplateLoader(config.Audiences)),
+		templateLoader: authorization.NewConfigMapTemplateLoader(cli, authorization.NewStaticTemplateLoader()),
 	}
 }
 
@@ -120,8 +120,11 @@ func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *Controller) Activate() {
+var _ platformctrl.Activable[authorization.ProviderConfig] = &Controller{}
+
+func (r *Controller) Activate(config authorization.ProviderConfig) {
 	r.active = true
+	r.config = config
 }
 
 func (r *Controller) Deactivate() {

--- a/controllers/authzctrl/reconcile_authconfig.go
+++ b/controllers/authzctrl/reconcile_authconfig.go
@@ -123,7 +123,7 @@ func (r *Controller) createAuthConfigTemplate(ctx context.Context, target *unstr
 		"Audiences": r.config.Audiences,
 	}
 
-	templ, err := r.templateLoader.Load(ctx, authType, templateData)
+	templ, err := r.templateLoader.Load(ctx, authType, types.NamespacedName{Namespace: target.GetNamespace(), Name: target.GetName()}, templateData)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not load template %s: %w", authType, err)
 	}

--- a/controllers/authzctrl/reconcile_authconfig.go
+++ b/controllers/authzctrl/reconcile_authconfig.go
@@ -118,7 +118,7 @@ func (r *Controller) createAuthConfigTemplate(ctx context.Context, target *unstr
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not detect authtype: %w", err)
 	}
 
-	templateData := map[string]interface{}{
+	templateData := map[string]any{
 		"Namespace": target.GetNamespace(),
 		"Audiences": r.config.Audiences,
 	}

--- a/controllers/authzctrl/reconcile_authconfig.go
+++ b/controllers/authzctrl/reconcile_authconfig.go
@@ -123,7 +123,7 @@ func (r *Controller) createAuthConfigTemplate(ctx context.Context, target *unstr
 		"Audiences": r.config.Audiences,
 	}
 
-	templ, err := r.templateLoader.Load(ctx, authType, types.NamespacedName{Namespace: target.GetNamespace(), Name: target.GetName()}, templateData)
+	templ, err := r.templateLoader.Load(ctx, authType, templateData)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not load template %s: %w", authType, err)
 	}

--- a/controllers/authzctrl/reconcile_authconfig.go
+++ b/controllers/authzctrl/reconcile_authconfig.go
@@ -118,7 +118,12 @@ func (r *Controller) createAuthConfigTemplate(ctx context.Context, target *unstr
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not detect authtype: %w", err)
 	}
 
-	templ, err := r.templateLoader.Load(ctx, authType, types.NamespacedName{Namespace: target.GetNamespace(), Name: target.GetName()})
+	templateData := map[string]interface{}{
+		"Namespace": target.GetNamespace(),
+		"Audiences": r.config.Audiences,
+	}
+
+	templ, err := r.templateLoader.Load(ctx, authType, types.NamespacedName{Namespace: target.GetNamespace(), Name: target.GetName()}, templateData)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not load template %s: %w", authType, err)
 	}

--- a/controllers/routingctrl/controller.go
+++ b/controllers/routingctrl/controller.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	platformctrl "github.com/opendatahub-io/odh-platform/controllers"
-
 	"github.com/opendatahub-io/odh-platform/pkg/platform"
 	"github.com/opendatahub-io/odh-platform/pkg/routing"
 	"github.com/opendatahub-io/odh-platform/pkg/unstruct"

--- a/controllers/routingctrl/controller.go
+++ b/controllers/routingctrl/controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	platformctrl "github.com/opendatahub-io/odh-platform/controllers"
+
 	"github.com/opendatahub-io/odh-platform/pkg/platform"
 	"github.com/opendatahub-io/odh-platform/pkg/routing"
 	"github.com/opendatahub-io/odh-platform/pkg/unstruct"
@@ -130,8 +131,11 @@ func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *Controller) Activate() {
+var _ platformctrl.Activable[routing.IngressConfig] = &Controller{}
+
+func (r *Controller) Activate(config routing.IngressConfig) {
 	r.active = true
+	r.config = config
 }
 
 func (r *Controller) Deactivate() {

--- a/controllers/types.go
+++ b/controllers/types.go
@@ -7,8 +7,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-type Activable interface {
-	Activate()
+type Activable[T any] interface {
+	Activate(config T)
 	Deactivate()
 }
 

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -25,6 +25,7 @@ import (
 	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/opendatahub-io/odh-platform/pkg/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -43,7 +44,7 @@ func NewStaticTemplateLoader() *staticTemplateLoader {
 	return &staticTemplateLoader{}
 }
 
-func (s *staticTemplateLoader) Load(ctx context.Context, authType AuthType, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
+func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
 	authConfig := authorinov1beta2.AuthConfig{}
 
 	templateContent := authConfigTemplateAnonymous
@@ -96,9 +97,9 @@ func NewConfigMapTemplateLoader(cli client.Client, fallback AuthConfigTemplateLo
 
 // TODO: check "authconfig-template" CM in key.Namespace to see if there is a "spec" to use, construct a AuthConfig object
 // https://issues.redhat.com/browse/RHOAIENG-847
-func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
+func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
 	// else
-	ac, err := c.fallback.Load(ctx, authType, templateData)
+	ac, err := c.fallback.Load(ctx, authType, key, templateData)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not load from fallback: %w", err)
 	}

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -36,22 +36,16 @@ var authConfigTemplateAnonymous []byte
 var authConfigTemplateUserDefined []byte
 
 type staticTemplateLoader struct {
-	audience []string
 }
 
 var _ AuthConfigTemplateLoader = (*staticTemplateLoader)(nil)
 
-func NewStaticTemplateLoader(audience []string) *staticTemplateLoader {
-	return &staticTemplateLoader{audience: audience}
+func NewStaticTemplateLoader() *staticTemplateLoader {
+	return &staticTemplateLoader{}
 }
 
-func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key types.NamespacedName) (authorinov1beta2.AuthConfig, error) {
+func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key types.NamespacedName, templateData map[string]interface{}) (authorinov1beta2.AuthConfig, error) {
 	authConfig := authorinov1beta2.AuthConfig{}
-
-	templateData := map[string]interface{}{
-		"Namespace": key.Namespace,
-		"Audiences": s.audience,
-	}
 
 	templateContent := authConfigTemplateAnonymous
 	if authType == UserDefined {
@@ -103,9 +97,9 @@ func NewConfigMapTemplateLoader(cli client.Client, fallback AuthConfigTemplateLo
 
 // TODO: check "authconfig-template" CM in key.Namespace to see if there is a "spec" to use, construct a AuthConfig object
 // https://issues.redhat.com/browse/RHOAIENG-847
-func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, key types.NamespacedName) (authorinov1beta2.AuthConfig, error) {
+func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]interface{}) (authorinov1beta2.AuthConfig, error) {
 	// else
-	ac, err := c.fallback.Load(ctx, authType, key)
+	ac, err := c.fallback.Load(ctx, authType, key, templateData)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not load from fallback: %w", err)
 	}

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -25,7 +25,6 @@ import (
 	authorinov1beta2 "github.com/kuadrant/authorino/api/v1beta2"
 	"github.com/opendatahub-io/odh-platform/pkg/schema"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,7 +43,7 @@ func NewStaticTemplateLoader() *staticTemplateLoader {
 	return &staticTemplateLoader{}
 }
 
-func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
+func (s *staticTemplateLoader) Load(ctx context.Context, authType AuthType, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
 	authConfig := authorinov1beta2.AuthConfig{}
 
 	templateContent := authConfigTemplateAnonymous
@@ -97,9 +96,9 @@ func NewConfigMapTemplateLoader(cli client.Client, fallback AuthConfigTemplateLo
 
 // TODO: check "authconfig-template" CM in key.Namespace to see if there is a "spec" to use, construct a AuthConfig object
 // https://issues.redhat.com/browse/RHOAIENG-847
-func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
+func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
 	// else
-	ac, err := c.fallback.Load(ctx, authType, key, templateData)
+	ac, err := c.fallback.Load(ctx, authType, templateData)
 	if err != nil {
 		return authorinov1beta2.AuthConfig{}, fmt.Errorf("could not load from fallback: %w", err)
 	}

--- a/pkg/authorization/authconfig.go
+++ b/pkg/authorization/authconfig.go
@@ -44,7 +44,7 @@ func NewStaticTemplateLoader() *staticTemplateLoader {
 	return &staticTemplateLoader{}
 }
 
-func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key types.NamespacedName, templateData map[string]interface{}) (authorinov1beta2.AuthConfig, error) {
+func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
 	authConfig := authorinov1beta2.AuthConfig{}
 
 	templateContent := authConfigTemplateAnonymous
@@ -65,7 +65,7 @@ func (s *staticTemplateLoader) Load(_ context.Context, authType AuthType, key ty
 	return authConfig, nil
 }
 
-func (s *staticTemplateLoader) resolveTemplate(tmpl []byte, data map[string]interface{}) ([]byte, error) {
+func (s *staticTemplateLoader) resolveTemplate(tmpl []byte, data map[string]any) ([]byte, error) {
 	engine, err := template.New("authconfig").Parse(string(tmpl))
 	if err != nil {
 		return []byte{}, fmt.Errorf("could not create template engine: %w", err)
@@ -97,7 +97,7 @@ func NewConfigMapTemplateLoader(cli client.Client, fallback AuthConfigTemplateLo
 
 // TODO: check "authconfig-template" CM in key.Namespace to see if there is a "spec" to use, construct a AuthConfig object
 // https://issues.redhat.com/browse/RHOAIENG-847
-func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]interface{}) (authorinov1beta2.AuthConfig, error) {
+func (c *configMapTemplateLoader) Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (authorinov1beta2.AuthConfig, error) {
 	// else
 	ac, err := c.fallback.Load(ctx, authType, key, templateData)
 	if err != nil {

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -37,5 +37,5 @@ type AuthTypeDetector interface {
 //   - Namespace / Resource name
 //   - Loader source
 type AuthConfigTemplateLoader interface {
-	Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]interface{}) (v1beta2.AuthConfig, error)
+	Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (v1beta2.AuthConfig, error)
 }

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -37,5 +37,5 @@ type AuthTypeDetector interface {
 //   - Namespace / Resource name
 //   - Loader source
 type AuthConfigTemplateLoader interface {
-	Load(ctx context.Context, authType AuthType, key types.NamespacedName) (v1beta2.AuthConfig, error)
+	Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]interface{}) (v1beta2.AuthConfig, error)
 }

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kuadrant/authorino/api/v1beta2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // ProviderConfig holds the configuration for the authorization component as defined by the platform.
@@ -37,5 +36,5 @@ type AuthTypeDetector interface {
 //   - Namespace / Resource name
 //   - Loader source
 type AuthConfigTemplateLoader interface {
-	Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (v1beta2.AuthConfig, error)
+	Load(ctx context.Context, authType AuthType, templateData map[string]any) (v1beta2.AuthConfig, error)
 }

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kuadrant/authorino/api/v1beta2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ProviderConfig holds the configuration for the authorization component as defined by the platform.
@@ -36,5 +37,5 @@ type AuthTypeDetector interface {
 //   - Namespace / Resource name
 //   - Loader source
 type AuthConfigTemplateLoader interface {
-	Load(ctx context.Context, authType AuthType, templateData map[string]any) (v1beta2.AuthConfig, error)
+	Load(ctx context.Context, authType AuthType, key types.NamespacedName, templateData map[string]any) (v1beta2.AuthConfig, error)
 }

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Resource functions", test.Unit(), func() {
 			// given
 			extractor := spi.NewAnnotationHostExtractor(";", "A", "B")
 			target := unstructured.Unstructured{
-				Object: map[string]interface{}{},
+				Object: map[string]any{},
 			}
 			target.SetAnnotations(map[string]string{
 				"A": "a.com;a2.com",

--- a/pkg/spi/host_extractor_test.go
+++ b/pkg/spi/host_extractor_test.go
@@ -14,8 +14,8 @@ var _ = Describe("Host extraction", test.Unit(), func() {
 		// given
 		extractor := spi.NewPathExpressionExtractor([]string{"status.url"})
 		target := unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"status": map[string]interface{}{
+			Object: map[string]any{
+				"status": map[string]any{
 					"url": "http://test.com",
 				},
 			},
@@ -33,7 +33,7 @@ var _ = Describe("Host extraction", test.Unit(), func() {
 		// given
 		extractor := spi.NewPathExpressionExtractor([]string{"status.url"})
 		target := unstructured.Unstructured{
-			Object: map[string]interface{}{},
+			Object: map[string]any{},
 		}
 		Expect(unstructured.SetNestedStringSlice(target.Object, []string{"test.com", "test2.com"}, "status", "url")).To(Succeed())
 
@@ -50,7 +50,7 @@ var _ = Describe("Host extraction", test.Unit(), func() {
 		// given
 		extractor := spi.NewPathExpressionExtractor([]string{"status.url"})
 		target := unstructured.Unstructured{
-			Object: map[string]interface{}{},
+			Object: map[string]any{},
 		}
 		Expect(unstructured.SetNestedStringSlice(target.Object, []string{"test.com", "http://test.com", "https://test.com"}, "status", "url")).To(Succeed())
 


### PR DESCRIPTION
When running in embedded mode the controller is only created once but it rely on configuration from updatable sources.

When e.g. the DSCI is updated, this does not get reflected to the runnning controller.

Now the Operator can pass the new Configuration per reconcile to the Controller

The Activable interface has expanded to take a generic any type as an argument in the Activate(T) method. The Controller should store and use this configuration for it's next reconcile.