### PR TITLE
feat(routing): support multi port services

### DIFF
--- a/controllers/routingctrl/controller_test.go
+++ b/controllers/routingctrl/controller_test.go
@@ -546,7 +546,8 @@ func hasNoAddressAnnotations(component *unstructured.Unstructured) func(g Gomega
 
 func routeExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {
-		g.Expect(exposedSvc.Spec.Ports).ToNot(HaveLen(0))
+		g.Expect(exposedSvc.Spec.Ports).ToNot(BeEmpty())
+
 		for _, exposedPort := range exposedSvc.Spec.Ports {
 			svcRoute := &openshiftroutev1.Route{}
 			if errGet := envTest.Get(ctx, types.NamespacedName{
@@ -566,7 +567,8 @@ func routeExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Conte
 
 func publicSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {
-		g.Expect(exposedSvc.Spec.Ports).ToNot(HaveLen(0))
+		g.Expect(exposedSvc.Spec.Ports).ToNot(BeEmpty())
+
 		for _, exposedPort := range exposedSvc.Spec.Ports {
 			publicSvc := &corev1.Service{}
 			if errGet := envTest.Get(ctx, types.NamespacedName{
@@ -587,13 +589,15 @@ func publicSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.C
 				HaveKeyWithValue(routingConfiguration.IngressSelectorLabel, routingConfiguration.IngressSelectorValue),
 			)
 		}
+
 		return nil
 	}
 }
 
 func publicGatewayExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {
-		g.Expect(exposedSvc.Spec.Ports).ToNot(HaveLen(0))
+		g.Expect(exposedSvc.Spec.Ports).ToNot(BeEmpty())
+
 		for _, exposedPort := range exposedSvc.Spec.Ports {
 			publicGateway := &v1beta1.Gateway{}
 			if errGet := envTest.Get(ctx, types.NamespacedName{
@@ -613,6 +617,7 @@ func publicGatewayExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx conte
 				),
 			)
 		}
+
 		return nil
 	}
 }
@@ -620,7 +625,9 @@ func publicGatewayExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx conte
 func publicVirtualSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {
 		publicVS := &v1beta1.VirtualService{}
-		g.Expect(exposedSvc.Spec.Ports).ToNot(HaveLen(0))
+
+		g.Expect(exposedSvc.Spec.Ports).ToNot(BeEmpty())
+
 		for _, exposedPort := range exposedSvc.Spec.Ports {
 			if errGet := envTest.Get(ctx, types.NamespacedName{
 				Name:      exposedSvc.Name + "-" + exposedPort.Name + "-" + exposedSvc.Namespace,
@@ -639,13 +646,15 @@ func publicVirtualSvcExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx co
 			g.Expect(publicVS).To(BeAttachedToGateways("mesh", exposedSvc.Name+"-"+exposedPort.Name+"-"+exposedSvc.Namespace))
 			g.Expect(publicVS).To(RouteToHost(exposedSvc.Name+"."+exposedSvc.Namespace+".svc.cluster.local", uint32(exposedPort.TargetPort.IntVal)))
 		}
+
 		return nil
 	}
 }
 
 func destinationRuleExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {
-		g.Expect(exposedSvc.Spec.Ports).ToNot(HaveLen(0))
+		g.Expect(exposedSvc.Spec.Ports).ToNot(BeEmpty())
+
 		for _, exposedPort := range exposedSvc.Spec.Ports {
 			destinationRule := &v1beta1.DestinationRule{}
 			if errGet := envTest.Get(ctx, types.NamespacedName{
@@ -662,13 +671,15 @@ func destinationRuleExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx con
 			)
 			g.Expect(destinationRule.Spec.GetTrafficPolicy().GetTls().GetMode()).To(Equal(istionetworkingv1beta1.ClientTLSSettings_DISABLE))
 		}
+
 		return nil
 	}
 }
 
 func ingressVirtualServiceExistsFor(exposedSvc *corev1.Service) func(g Gomega, ctx context.Context) error {
 	return func(g Gomega, ctx context.Context) error {
-		g.Expect(exposedSvc.Spec.Ports).ToNot(HaveLen(0))
+		g.Expect(exposedSvc.Spec.Ports).ToNot(BeEmpty())
+
 		for _, exposedPort := range exposedSvc.Spec.Ports {
 			routerVS := &v1beta1.VirtualService{}
 			if errGet := envTest.Get(ctx, types.NamespacedName{
@@ -682,6 +693,7 @@ func ingressVirtualServiceExistsFor(exposedSvc *corev1.Service) func(g Gomega, c
 			g.Expect(routerVS).To(BeAttachedToGateways(routingConfiguration.IngressService))
 			g.Expect(routerVS).To(RouteToHost(exposedSvc.Name+"."+exposedSvc.Namespace+".svc.cluster.local", uint32(exposedPort.TargetPort.IntValue())))
 		}
+
 		return nil
 	}
 }

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/opendatahub-io/odh-platform/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform/pkg/config"
@@ -34,7 +35,7 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 
 	renderedSelectors, errLables := config.ResolveSelectors(r.component.ServiceSelector, target)
 	if errLables != nil {
-		return fmt.Errorf("could not render labels for ServiceSelector %v. Error %w", r.component.ServiceSelector, errLables)
+		return fmt.Errorf("could not render labels for ServiceSelector %v: %w", r.component.ServiceSelector, errLables)
 	}
 
 	exportedServices, errSvcGet := getExportedServices(ctx, r.Client, renderedSelectors, target)
@@ -67,45 +68,51 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 func (r *Controller) exportService(ctx context.Context, target *unstructured.Unstructured, exportedSvc *corev1.Service, domain string) error {
 	exportModes := r.extractExportModes(target)
 
-	templateData := routing.NewExposedServiceConfig(exportedSvc, r.config, domain)
+	externalHosts := []string{}
+	publicHosts := []string{}
 
 	// To establish ownership for watched component
 	ownershipLabels := append(labels.AsOwner(target), labels.AppManagedBy("odh-routing-controller"))
 
-	for _, exportMode := range exportModes {
-		resources, err := r.templateLoader.Load(templateData, exportMode)
-		if err != nil {
-			return fmt.Errorf("could not load templates for type %s: %w", exportMode, err)
-		}
+	for _, exportedSvcPort := range exportedSvc.Spec.Ports {
+		templateData := routing.NewExposedServiceConfig(exportedSvc, exportedSvcPort, r.config, domain)
 
-		ownershipLabels = append(ownershipLabels, labels.ExportType(exportMode))
-		if errApply := unstruct.Apply(ctx, r.Client, resources, ownershipLabels...); errApply != nil {
-			return fmt.Errorf("could not apply routing resources for type %s: %w", exportMode, errApply)
+		for _, exportMode := range exportModes {
+			resources, err := r.templateLoader.Load(templateData, exportMode)
+			if err != nil {
+				return fmt.Errorf("could not load templates for type %s: %w", exportMode, err)
+			}
+
+			ownershipLabels = append(ownershipLabels, labels.ExportType(exportMode))
+			if errApply := unstruct.Apply(ctx, r.Client, resources, ownershipLabels...); errApply != nil {
+				return fmt.Errorf("could not apply routing resources for type %s: %w", exportMode, errApply)
+			}
+
+			switch exportMode {
+			case routing.ExternalRoute:
+				externalHosts = append(externalHosts, templateData.ExternalHost())
+			case routing.PublicRoute:
+				publicHosts = append(publicHosts, templateData.PublicHosts()...)
+			}
 		}
 	}
 
-	return r.propagateHostsToWatchedCR(target, templateData)
+	return r.propagateHostsToWatchedCR(target, publicHosts, externalHosts)
 }
 
-func (r *Controller) propagateHostsToWatchedCR(target *unstructured.Unstructured, data *routing.ExposedServiceConfig) error {
-	exportModes := r.extractExportModes(target)
-
+func (r *Controller) propagateHostsToWatchedCR(target *unstructured.Unstructured, publicHosts, externalHosts []string) error {
 	// Remove all existing routing addresses
 	metaOptions := []metadata.Option{
 		annotations.Remove(annotations.RoutingAddressesExternal("")),
 		annotations.Remove(annotations.RoutingAddressesPublic("")),
 	}
 
-	// TODO(mvp): put the logic of creating host names into a single place
-	for _, exportMode := range exportModes {
-		switch exportMode {
-		case routing.ExternalRoute:
-			externalAddress := annotations.RoutingAddressesExternal(fmt.Sprintf("%s-%s.%s", data.ServiceName, data.ServiceNamespace, data.Domain))
-			metaOptions = append(metaOptions, externalAddress)
-		case routing.PublicRoute:
-			publicAddresses := annotations.RoutingAddressesPublic(fmt.Sprintf("%[1]s.%[2]s;%[1]s.%[2]s.svc;%[1]s.%[2]s.svc.cluster.local", data.PublicServiceName, data.GatewayNamespace))
-			metaOptions = append(metaOptions, publicAddresses)
-		}
+	if len(publicHosts) > 0 {
+		metaOptions = append(metaOptions, annotations.RoutingAddressesPublic(strings.Join(publicHosts, ";")))
+	}
+
+	if len(externalHosts) > 0 {
+		metaOptions = append(metaOptions, annotations.RoutingAddressesExternal(strings.Join(externalHosts, ";")))
 	}
 
 	metadata.ApplyMetaOptions(target, metaOptions...)

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -22,6 +22,16 @@ var _ = Describe("Resource functions", test.Unit(), func() {
 			IngressSelectorValue: "rhoai-gateway",
 			IngressService:       "rhoai-router-ingress",
 		}
+		httpPort := corev1.ServicePort{
+			Name:        "http-api",
+			Port:        80,
+			AppProtocol: ptr.To("http"),
+		}
+		grpcPort := corev1.ServicePort{
+			Name:        "grpc-api",
+			Port:        90,
+			AppProtocol: ptr.To("grpc"),
+		}
 
 		data := routing.NewExposedServiceConfig(&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -30,14 +40,12 @@ var _ = Describe("Resource functions", test.Unit(), func() {
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
-					{
-						Name:        "http-api",
-						Port:        80,
-						AppProtocol: ptr.To("http"),
-					},
+					httpPort,
+					grpcPort,
 				},
 			},
-		}, config, "app-crc.testing")
+		},
+			httpPort, config, "app-crc.testing")
 
 		It("should load public resources", func() {
 			// given

--- a/pkg/routing/template/routing_external.yaml
+++ b/pkg/routing/template/routing_external.yaml
@@ -7,7 +7,7 @@ spec:
   to:
     kind: Service
     name: {{ .IngressService }}
-  host: {{ .PublicServiceName }}.{{ .Domain }}
+  host: {{ .ExternalHost }}
   port:
     targetPort: https
   tls:
@@ -23,7 +23,7 @@ spec:
   gateways:
   - {{ .IngressService }} # name of wildcard Gateway
   hosts:
-  - {{ .PublicServiceName}}.{{ .Domain }} # hostname on the Route
+  - {{ .ExternalHost }} # hostname on the Route
   http:
   - name: {{ .PublicServiceName }}-ingress
     route:

--- a/pkg/routing/template/routing_public.yaml
+++ b/pkg/routing/template/routing_public.yaml
@@ -25,9 +25,9 @@ spec:
     {{ .IngressSelectorLabel }}: {{ .IngressSelectorValue }}
   servers:
   - hosts:
-    - {{ .PublicServiceName }}.{{ .GatewayNamespace }}
-    - {{ .PublicServiceName }}.{{ .GatewayNamespace }}.svc
-    - {{ .PublicServiceName }}.{{ .GatewayNamespace }}.svc.cluster.local
+{{ range $host := .PublicHosts }}
+    - {{ $host }}
+{{ end }}
     port:
       name: https
       number: 443
@@ -47,9 +47,9 @@ spec:
   - {{ .PublicServiceName }} # Gateway for public service
   - mesh # for clients in the mesh
   hosts:
-  - {{ .PublicServiceName }}.{{ .GatewayNamespace }}
-  - {{ .PublicServiceName }}.{{ .GatewayNamespace }}.svc
-  - {{ .PublicServiceName }}.{{ .GatewayNamespace }}.svc.cluster.local
+{{ range $host := .PublicHosts }}
+    - {{ $host }}
+{{ end }}
   http:
   - name: {{ .PublicServiceName }}
     route:

--- a/pkg/routing/types.go
+++ b/pkg/routing/types.go
@@ -73,13 +73,25 @@ type ExposedServiceConfig struct {
 	Domain string
 }
 
-func NewExposedServiceConfig(svc *corev1.Service, config IngressConfig, domain string) *ExposedServiceConfig {
+func (t ExposedServiceConfig) ExternalHost() string {
+	return t.PublicServiceName + "." + t.Domain
+}
+
+func (t ExposedServiceConfig) PublicHosts() []string {
+	return []string{
+		t.PublicServiceName + "." + t.IngressConfig.GatewayNamespace,
+		t.PublicServiceName + "." + t.IngressConfig.GatewayNamespace + ".svc",
+		t.PublicServiceName + "." + t.IngressConfig.GatewayNamespace + ".svc.cluster.local",
+	}
+}
+
+func NewExposedServiceConfig(svc *corev1.Service, svcPort corev1.ServicePort, config IngressConfig, domain string) *ExposedServiceConfig {
 	return &ExposedServiceConfig{
 		IngressConfig:     config,
-		PublicServiceName: svc.GetName() + "-" + svc.GetNamespace(),
+		PublicServiceName: svc.GetName() + "-" + svcPort.Name + "-" + svc.GetNamespace(),
 		ServiceName:       svc.GetName(),
 		ServiceNamespace:  svc.GetNamespace(),
-		ServiceTargetPort: svc.Spec.Ports[0].TargetPort.String(),
+		ServiceTargetPort: svcPort.TargetPort.String(),
 		Domain:            domain,
 	}
 }


### PR DESCRIPTION
The selected Service might have multiple ports to different types of apis or protocols. In the previous version, we only exported the first port under the name ServiceName+ServiceNamespace.

With this change we include all ports on the service and export them as ServiceName+ServicePortName+SerivceNamespace

The PublicServiceName is changed to include the ServicePortName which means we now also loop over each ServicePort in the exportedService.

Also moved the Host creation/concat into functions of the TemplateData object which means that they are constructed in one location and reused between templates and metadata updates in the api.