### PR TITLE
ci: run tests only for test job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - run: make
+      - run: make test


### PR DESCRIPTION
Running default `make` targets results in running linter before the actual tests are executed. As we have separate job for linter we should focus on running tests instead so we can get feedback for both aspects at the same time when PR is opened/updated. Currently both jobs fail on linter so tests are never executed.

In order to run tests for test job, `make test` target is invoked instead.