### PR TITLE
ci(linter): bumps golangci-lint to latest version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.60.3
           skip-cache: true
           args: --timeout 5m0s

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ $(LOCALBIN)/yq:
 	$(call header,"Installing $(notdir $@)")
 	GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
 
-LINT_VERSION=v1.59.1
+LINT_VERSION=v1.60.3
 $(LOCALBIN)/golangci-lint:
 	$(call header,"Installing $(notdir $@)")
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(LINT_VERSION)


### PR DESCRIPTION
Modifies both make toolchain and GitHub action.