### PR TITLE
bug: avoid failing when not finding status expressions

### DIFF
--- a/controllers/authzctrl/controller.go
+++ b/controllers/authzctrl/controller.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const name = "authorization"
@@ -115,8 +116,8 @@ func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 				Kind:       r.protectedResource.ResourceReference.Kind,
 			},
 		}, builder.OnlyMetadata).
-		Owns(&authorinov1beta2.AuthConfig{}).
-		Owns(&istiosecurityv1beta1.AuthorizationPolicy{}).
+		Owns(&authorinov1beta2.AuthConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&istiosecurityv1beta1.AuthorizationPolicy{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }
 

--- a/controllers/routingctrl/controller.go
+++ b/controllers/routingctrl/controller.go
@@ -98,8 +98,6 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		errs = append(errs, reconciler(ctx, sourceRes))
 	}
 
-	errs = append(errs, unstruct.Patch(ctx, r.Client, sourceRes))
-
 	return ctrl.Result{}, errors.Join(errs...)
 }
 

--- a/controllers/routingctrl/delete_resources.go
+++ b/controllers/routingctrl/delete_resources.go
@@ -32,12 +32,12 @@ func (r *Controller) removeUnusedRoutingResources(ctx context.Context, target *u
 func (r *Controller) handleResourceDeletion(ctx context.Context, sourceRes *unstructured.Unstructured) error {
 	exportModes := r.extractExportModes(sourceRes)
 	if len(exportModes) == 0 {
-		r.log.Info("No export modes found, skipping deletion logic", "sourceRes", sourceRes)
+		r.log.Info("no export modes found, skipping deletion logic", "sourceRes", sourceRes)
 
 		return nil
 	}
 
-	r.log.Info("Handling deletion of dependent resources", "sourceRes", sourceRes)
+	r.log.Info("handling deletion of dependent resources", "sourceRes", sourceRes)
 
 	gvks := routingResourceGVKs(exportModes...)
 

--- a/controllers/routingctrl/exported_svc_locator.go
+++ b/controllers/routingctrl/exported_svc_locator.go
@@ -48,6 +48,11 @@ func (e *ExportedServiceNotFoundError) Error() string {
 	return fmt.Sprintf("no exported services found for target %s/%s (%s)", e.target.GetNamespace(), e.target.GetName(), e.target.GetObjectKind().GroupVersionKind().String())
 }
 
+func (e *ExportedServiceNotFoundError) Is(target error) bool {
+	_, ok := target.(*ExportedServiceNotFoundError)
+	return ok
+}
+
 func isExportedServiceNotFoundError(err error) bool {
 	return errors.Is(err, &ExportedServiceNotFoundError{})
 }

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -27,7 +27,7 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 		return r.propagateHostsToWatchedCR(ctx, target, nil, nil)
 	}
 
-	r.log.Info("Reconciling resources for target", "target", target)
+	r.log.Info("reconciling resources for target", "target", target)
 
 	renderedSelectors, errLables := config.ResolveSelectors(r.component.ServiceSelector, target)
 	if errLables != nil {

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -50,16 +50,20 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 		return fmt.Errorf("could not get domain: %w", errDomain)
 	}
 
-	targetPublicHosts := []string{}
-	targetExternalHosts := []string{}
 	var errSvcExport []error
+
+	var targetPublicHosts []string
+
+	var targetExternalHosts []string
 
 	for i := range exportedServices {
 		servicePublicHosts, serviceExternalHosts, errExport := r.exportService(ctx, target, &exportedServices[i], domain)
 		if errExport != nil {
 			errSvcExport = append(errSvcExport, errExport)
+
 			continue
 		}
+
 		targetPublicHosts = append(targetPublicHosts, servicePublicHosts...)
 		targetExternalHosts = append(targetExternalHosts, serviceExternalHosts...)
 	}
@@ -71,11 +75,10 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 	return r.propagateHostsToWatchedCR(ctx, target, targetPublicHosts, targetExternalHosts)
 }
 
-func (r *Controller) exportService(ctx context.Context, target *unstructured.Unstructured, exportedSvc *corev1.Service, domain string) ([]string, []string, error) {
+//nolint:nonamedreturns //reason make up your mind, nonamedreturns vs gocritic
+func (r *Controller) exportService(ctx context.Context, target *unstructured.Unstructured,
+	exportedSvc *corev1.Service, domain string) (publicHosts, externalHosts []string, err error) {
 	exportModes := r.extractExportModes(target)
-
-	externalHosts := []string{}
-	publicHosts := []string{}
 
 	// To establish ownership for watched component
 	ownershipLabels := append(labels.AsOwner(target), labels.AppManagedBy("odh-routing-controller"))

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -23,12 +23,8 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 
 	if len(exportModes) == 0 {
 		r.log.Info("No export mode found for target")
-		metadata.ApplyMetaOptions(target,
-			annotations.Remove(annotations.RoutingAddressesExternal("")),
-			annotations.Remove(annotations.RoutingAddressesPublic("")),
-		)
 
-		return nil
+		return r.propagateHostsToWatchedCR(ctx, target, nil, nil)
 	}
 
 	r.log.Info("Reconciling resources for target", "target", target)
@@ -97,38 +93,49 @@ func (r *Controller) exportService(ctx context.Context, target *unstructured.Uns
 		}
 	}
 
-	return r.propagateHostsToWatchedCR(target, publicHosts, externalHosts)
+	return r.propagateHostsToWatchedCR(ctx, target, publicHosts, externalHosts)
 }
 
-func (r *Controller) propagateHostsToWatchedCR(target *unstructured.Unstructured, publicHosts, externalHosts []string) error {
-	// Remove all existing routing addresses
-	metaOptions := []metadata.Option{
-		annotations.Remove(annotations.RoutingAddressesExternal("")),
-		annotations.Remove(annotations.RoutingAddressesPublic("")),
-	}
+func (r *Controller) propagateHostsToWatchedCR(ctx context.Context, target *unstructured.Unstructured, publicHosts, externalHosts []string) error {
+	err := unstruct.PatchWithRetry(ctx, r.Client, target, func() error {
+		// Always remove the annotations first
+		annotations.Remove(annotations.RoutingAddressesExternal(""))(target)
+		annotations.Remove(annotations.RoutingAddressesPublic(""))(target)
 
-	if len(publicHosts) > 0 {
-		metaOptions = append(metaOptions, annotations.RoutingAddressesPublic(strings.Join(publicHosts, ";")))
-	}
+		var metaOptions []metadata.Option
 
-	if len(externalHosts) > 0 {
-		metaOptions = append(metaOptions, annotations.RoutingAddressesExternal(strings.Join(externalHosts, ";")))
-	}
+		if len(publicHosts) > 0 {
+			metaOptions = append(metaOptions, annotations.RoutingAddressesPublic(strings.Join(publicHosts, ";")))
+		}
 
-	metadata.ApplyMetaOptions(target, metaOptions...)
+		if len(externalHosts) > 0 {
+			metaOptions = append(metaOptions, annotations.RoutingAddressesExternal(strings.Join(externalHosts, ";")))
+		}
+
+		metadata.ApplyMetaOptions(target, metaOptions...)
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to propagate hosts to watched CR %s/%s: %w", target.GetNamespace(), target.GetName(), err)
+	}
 
 	return nil
 }
 
 func (r *Controller) ensureResourceHasFinalizer(ctx context.Context, target *unstructured.Unstructured) error {
 	if !controllerutil.ContainsFinalizer(target, finalizerName) {
-		if err := unstruct.PatchMutate(ctx, r.Client, target, func() error {
+		if err := unstruct.PatchWithRetry(ctx, r.Client, target, func() error {
 			controllerutil.AddFinalizer(target, finalizerName)
+
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed to patch finalizer to resource %s/%s: %w", target.GetNamespace(), target.GetName(), err)
+			return fmt.Errorf("failed to patch finalizer to %s (in %s): %w",
+				target.GroupVersionKind().String(), target.GetNamespace(), err)
 		}
 	}
+
 	return nil
 }
 

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -146,11 +146,6 @@ func (r *Controller) extractExportModes(target *unstructured.Unstructured) []rou
 			routeType, valid := routing.IsValidRouteType(key)
 			if valid {
 				validRouteTypes = append(validRouteTypes, routeType)
-			} else {
-				r.log.Info("Invalid route type found",
-					"invalidRouteType", routeType,
-					"resourceName", target.GetName(),
-					"resourceNamespace", target.GetNamespace())
 			}
 		}
 	}

--- a/pkg/spi/types.go
+++ b/pkg/spi/types.go
@@ -94,7 +94,7 @@ func UnifiedHostExtractor(extractors ...HostExtractor) HostExtractor { //nolint:
 }
 
 func NewPathExpressionExtractor(paths []string) HostExtractor {
-	extractHosts := func(target *unstructured.Unstructured, splitPath []string) ([]string, error) {
+	extractHosts := func(target *unstructured.Unstructured, splitPath []string) ([]string, error) { //nolint:unparam //reason Part of HostExtractor interface
 		// extracting as string
 		if foundHost, found, err := unstructured.NestedString(target.Object, splitPath...); err == nil && found {
 			return []string{foundHost}, nil
@@ -105,7 +105,8 @@ func NewPathExpressionExtractor(paths []string) HostExtractor {
 			return foundHosts, nil
 		}
 
-		return nil, fmt.Errorf("neither string nor slice of strings found at path %v", splitPath)
+		// TODO: Nothing found yet, move on no error?
+		return []string{}, nil
 	}
 
 	return func(target *unstructured.Unstructured) ([]string, error) {

--- a/pkg/unstruct/funcs.go
+++ b/pkg/unstruct/funcs.go
@@ -66,7 +66,7 @@ func IsMarkedForDeletion(target *unstructured.Unstructured) bool {
 // Patch updates the specified Kubernetes resource by applying changes from the provided target object.
 // In case of conflicts, it will retry using default strategy.
 func Patch(ctx context.Context, cli client.Client, target *unstructured.Unstructured) error {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		currentRes := &unstructured.Unstructured{}
 		currentRes.SetGroupVersionKind(target.GroupVersionKind())
 

--- a/pkg/unstruct/funcs.go
+++ b/pkg/unstruct/funcs.go
@@ -71,12 +71,12 @@ func Patch(ctx context.Context, cli client.Client, target *unstructured.Unstruct
 		currentRes.SetGroupVersionKind(target.GroupVersionKind())
 
 		if err := cli.Get(ctx, client.ObjectKeyFromObject(target), currentRes); err != nil {
-			return fmt.Errorf("failed re-fetching resource: %w", err)
+			return err //nolint:wrapcheck // Return unwrapped error for retry logic
 		}
 
 		patch := client.MergeFrom(currentRes)
 		if errPatch := cli.Patch(ctx, target, patch); errPatch != nil {
-			return fmt.Errorf("failed to patch: %w", errPatch)
+			return errPatch //nolint:wrapcheck // Return unwrapped error for retry logic
 		}
 
 		return nil


### PR DESCRIPTION
The status paths might not have been written at the time of first n executions and should only be retried on new reconcile attempts.