### PR TITLE
feat(routing): use PatchWithRetry

### DIFF
--- a/controllers/routingctrl/controller.go
+++ b/controllers/routingctrl/controller.go
@@ -98,8 +98,6 @@ func (r *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		errs = append(errs, reconciler(ctx, sourceRes))
 	}
 
-	errs = append(errs, unstruct.Patch(ctx, r.Client, sourceRes))
-
 	return ctrl.Result{}, errors.Join(errs...)
 }
 

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -23,12 +23,8 @@ func (r *Controller) createRoutingResources(ctx context.Context, target *unstruc
 
 	if len(exportModes) == 0 {
 		r.log.Info("No export mode found for target")
-		metadata.ApplyMetaOptions(target,
-			annotations.Remove(annotations.RoutingAddressesExternal("")),
-			annotations.Remove(annotations.RoutingAddressesPublic("")),
-		)
 
-		return nil
+		return r.propagateHostsToWatchedCR(ctx, target, nil, nil)
 	}
 
 	r.log.Info("Reconciling resources for target", "target", target)
@@ -97,33 +93,46 @@ func (r *Controller) exportService(ctx context.Context, target *unstructured.Uns
 		}
 	}
 
-	return r.propagateHostsToWatchedCR(target, publicHosts, externalHosts)
+	return r.propagateHostsToWatchedCR(ctx, target, publicHosts, externalHosts)
 }
 
-func (r *Controller) propagateHostsToWatchedCR(target *unstructured.Unstructured, publicHosts, externalHosts []string) error {
-	// Remove all existing routing addresses
-	metaOptions := []metadata.Option{
-		annotations.Remove(annotations.RoutingAddressesExternal("")),
-		annotations.Remove(annotations.RoutingAddressesPublic("")),
-	}
+func (r *Controller) propagateHostsToWatchedCR(ctx context.Context, target *unstructured.Unstructured, publicHosts, externalHosts []string) error {
+	err := unstruct.PatchWithRetry(ctx, r.Client, target, func() error {
+		// Always remove the annotations first
+		annotations.Remove(annotations.RoutingAddressesExternal(""))(target)
+		annotations.Remove(annotations.RoutingAddressesPublic(""))(target)
 
-	if len(publicHosts) > 0 {
-		metaOptions = append(metaOptions, annotations.RoutingAddressesPublic(strings.Join(publicHosts, ";")))
-	}
+		var metaOptions []metadata.Option
 
-	if len(externalHosts) > 0 {
-		metaOptions = append(metaOptions, annotations.RoutingAddressesExternal(strings.Join(externalHosts, ";")))
-	}
+		if len(publicHosts) > 0 {
+			metaOptions = append(metaOptions, annotations.RoutingAddressesPublic(strings.Join(publicHosts, ";")))
+		}
 
-	metadata.ApplyMetaOptions(target, metaOptions...)
+		if len(externalHosts) > 0 {
+			metaOptions = append(metaOptions, annotations.RoutingAddressesExternal(strings.Join(externalHosts, ";")))
+		}
+
+		metadata.ApplyMetaOptions(target, metaOptions...)
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to propagate hosts to watched CR %s/%s: %w", target.GetNamespace(), target.GetName(), err)
+	}
 
 	return nil
 }
 
 func (r *Controller) ensureResourceHasFinalizer(ctx context.Context, target *unstructured.Unstructured) error {
-	if controllerutil.AddFinalizer(target, finalizerName) {
-		if err := unstruct.Patch(ctx, r.Client, target); err != nil {
-			return fmt.Errorf("failed to patch finalizer to resource %s/%s: %w", target.GetNamespace(), target.GetName(), err)
+	if !controllerutil.ContainsFinalizer(target, finalizerName) {
+		if err := unstruct.PatchWithRetry(ctx, r.Client, target, func() error {
+			controllerutil.AddFinalizer(target, finalizerName)
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to patch finalizer to %s (in %s): %w",
+				target.GroupVersionKind().String(), target.GetNamespace(), err)
 		}
 	}
 

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -131,7 +131,7 @@ func (r *Controller) ensureResourceHasFinalizer(ctx context.Context, target *uns
 
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed to patch finalizer to %s (in %s): %w",
+			return fmt.Errorf("failed to add finalizer to %s (in %s): %w",
 				target.GroupVersionKind().String(), target.GetNamespace(), err)
 		}
 	}

--- a/controllers/routingctrl/reconcile_resources.go
+++ b/controllers/routingctrl/reconcile_resources.go
@@ -98,11 +98,11 @@ func (r *Controller) exportService(ctx context.Context, target *unstructured.Uns
 
 func (r *Controller) propagateHostsToWatchedCR(ctx context.Context, target *unstructured.Unstructured, publicHosts, externalHosts []string) error {
 	err := unstruct.PatchWithRetry(ctx, r.Client, target, func() error {
-		// Always remove the annotations first
-		annotations.Remove(annotations.RoutingAddressesExternal(""))(target)
-		annotations.Remove(annotations.RoutingAddressesPublic(""))(target)
-
-		var metaOptions []metadata.Option
+		// Remove all existing routing addresses
+		metaOptions := []metadata.Option{
+			annotations.Remove(annotations.RoutingAddressesExternal("")),
+			annotations.Remove(annotations.RoutingAddressesPublic("")),
+		}
 
 		if len(publicHosts) > 0 {
 			metaOptions = append(metaOptions, annotations.RoutingAddressesPublic(strings.Join(publicHosts, ";")))


### PR DESCRIPTION
Summary:

- Introduces unstruct.PatchWithRetry using controllerutil.CreateOrPatch for conflict-resistant updates
- Refactors finalizer management and host propagation to use the new retry mechanism
- Removes unnecessary unstruct.Patch call from the main Reconcile function, instead moving `PatchWithRetry` calls to where they are needed.